### PR TITLE
Modern radial menu for assistant orb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 
+node_modules/
+dist/

--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import type { AssistantMessage, Post } from "../types";
+import RadialMenu from "./RadialMenu";
 
 /**
  * Assistant Orb — circular quick menu + 60fps drag + voice.
@@ -102,11 +103,6 @@ export default function AssistantOrb() {
   const interimRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const msgListRef = useRef<HTMLDivElement | null>(null);
-  const btnChatRef   = useRef<HTMLButtonElement | null>(null);
-  const btnReactRef  = useRef<HTMLButtonElement | null>(null);
-  const btnCommentRef= useRef<HTMLButtonElement | null>(null);
-  const btnRemixRef  = useRef<HTMLButtonElement | null>(null);
-  const btnProfileRef= useRef<HTMLButtonElement | null>(null);
 
   // feed context
   useEffect(() => {
@@ -228,18 +224,6 @@ export default function AssistantOrb() {
     el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
   }
 
-  function place(el: HTMLElement | null, rad: number, deg: number) {
-    if (!el) return;
-    const { x, y } = posRef.current;
-    const cx = x + ORB_SIZE / 2;
-    const cy = y + ORB_SIZE / 2;
-    const a = (deg * Math.PI) / 180;
-    const bx = cx + rad * Math.cos(a) - el.offsetWidth / 2;
-    const by = cy + rad * Math.sin(a) - el.offsetHeight / 2;
-    el.style.position = "fixed";
-    el.style.left = `${bx}px`;
-    el.style.top = `${by}px`;
-  }
 
   function updateAnchors() {
     if (typeof window === "undefined") return;
@@ -277,13 +261,6 @@ export default function AssistantOrb() {
       else { s.left = `${x - 8}px`; s.right = ""; s.transform = "translateX(-100%)"; }
     }
 
-    if (menuOpen && !dragging) {
-      place(btnChatRef.current!,    84, -90); // top
-      place(btnReactRef.current!,   74, 220); // bottom-left
-      place(btnCommentRef.current!, 78, 270); // bottom
-      place(btnRemixRef.current!,   74, 320); // bottom-right
-      place(btnProfileRef.current!, 74, 180); // left
-    }
   }
 
   // pointer handlers
@@ -482,19 +459,6 @@ export default function AssistantOrb() {
     backdropFilter: "blur(10px) saturate(140%)",
     animation: "panelIn .2s ease-out",
   };
-  const rbtn: React.CSSProperties = {
-    position: "fixed",
-    zIndex: 9998,
-    width: 40, height: 40,
-    borderRadius: 999,
-    display: "grid",
-    placeItems: "center",
-    background: "rgba(14,16,22,.7)",
-    border: "1px solid rgba(255,255,255,.15)",
-    color: "#fff",
-    cursor: "pointer",
-    backdropFilter: "blur(8px) saturate(140%)",
-  };
 
   return (
     <>
@@ -520,17 +484,59 @@ export default function AssistantOrb() {
       </button>
 
       {/* Radial menu */}
-      {menuOpen && !dragging && (
-        <>
-          <button ref={btnChatRef} style={rbtn} aria-label="Chat" title="Chat" onClick={() => { setOpen(v => !v); setPetal(null); requestAnimationFrame(updateAnchors); }}>💬</button>
-          <button ref={btnReactRef} style={rbtn} aria-label="React" title="React" onClick={() => setPetal("react")}>👏</button>
-          <button ref={btnCommentRef} style={rbtn} aria-label="Comment" title="Comment" onClick={() => setPetal("comment")}>✍️</button>
-          <button ref={btnRemixRef} style={rbtn} aria-label="Remix" title="Remix" onClick={() => setPetal("remix")}>🎬</button>
-          <button ref={btnProfileRef} style={{ ...rbtn, padding: 0, overflow: "hidden" }} aria-label="Profile" title="Profile" onClick={() => ctxPost && bus.emit?.("profile:open", { id: ctxPost.author })}>
-            <img src={ctxPost?.authorAvatar || "/avatar.jpg"} alt="" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-          </button>
-        </>
-      )}
+      <RadialMenu
+        open={menuOpen && !dragging}
+        center={{ x: pos.x + ORB_SIZE / 2, y: pos.y + ORB_SIZE / 2 }}
+        items={[
+          {
+            id: "chat",
+            icon: "💬",
+            label: "Chat",
+            onSelect: () => {
+              setOpen(v => !v);
+              setPetal(null);
+              setMenuOpen(false);
+              requestAnimationFrame(updateAnchors);
+            },
+          },
+          {
+            id: "react",
+            icon: "👏",
+            label: "React",
+            onSelect: () => {
+              setPetal("react");
+              setMenuOpen(false);
+            },
+          },
+          {
+            id: "comment",
+            icon: "✍️",
+            label: "Comment",
+            onSelect: () => {
+              setPetal("comment");
+              setMenuOpen(false);
+            },
+          },
+          {
+            id: "remix",
+            icon: "🎬",
+            label: "Remix",
+            onSelect: () => {
+              setPetal("remix");
+              setMenuOpen(false);
+            },
+          },
+          {
+            id: "share",
+            icon: "🔗",
+            label: "Share",
+            onSelect: () => {
+              setPetal("share");
+              setMenuOpen(false);
+            },
+          },
+        ]}
+      />
 
       {/* toast + interim */}
       {toast && <div ref={toastRef} style={toastBoxStyle} aria-live="polite">{toast}</div>}

--- a/src/components/RadialMenu.css
+++ b/src/components/RadialMenu.css
@@ -1,0 +1,26 @@
+.radial-menu{
+  position:fixed;
+  width:0;
+  height:0;
+  pointer-events:none;
+  z-index:9998;
+}
+.radial-menu__btn{
+  position:absolute;
+  width:40px;
+  height:40px;
+  border-radius:50%;
+  border:none;
+  background:rgba(14,16,22,.7);
+  border:1px solid rgba(255,255,255,.15);
+  color:#fff;
+  cursor:pointer;
+  backdrop-filter:blur(8px) saturate(140%);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  pointer-events:auto;
+  transform:rotate(var(--angle)) translate(0,-80px) rotate(calc(var(--angle)*-1));
+  transition:background .2s;
+}
+.radial-menu__btn:hover{background:rgba(255,255,255,.15);}

--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import "./RadialMenu.css";
+
+export interface RadialMenuItem {
+  id: string;
+  icon: React.ReactNode;
+  label: string;
+  onSelect: () => void;
+}
+
+export default function RadialMenu({
+  open,
+  center,
+  items,
+}: {
+  open: boolean;
+  center: { x: number; y: number };
+  items: RadialMenuItem[];
+}) {
+  if (!open) return null;
+  const step = 360 / items.length;
+  return (
+    <div
+      className="radial-menu"
+      style={{ left: center.x, top: center.y, transform: "translate(-50%, -50%)" }}
+    >
+      {items.map((it, i) => (
+        <button
+          key={it.id}
+          className="radial-menu__btn"
+          style={{ "--angle": `${i * step}deg` } as React.CSSProperties }
+          onClick={it.onSelect}
+          aria-label={it.label}
+          title={it.label}
+        >
+          {it.icon}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Introduce reusable `RadialMenu` component for clean two-step menu interactions
- Replace manual orb menu buttons with `RadialMenu` including new Share option
- Ignore build artifacts via `.gitignore`

## Testing
- `npm run build`
- `npm test` *(fails: Cannot read properties of undefined (reading 'style') in PostCard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689ebd41ffa083219d77661cd9b89065