### PR TITLE
feat: theme toggle with glassmorphism palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# Ignore dependencies and build output
+node_modules/
+dist/
+
+# Logs
+*.log
 

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,8 +1,16 @@
-import React, { useLayoutEffect, useRef } from "react";
+import React, { useLayoutEffect, useRef, useState, useEffect } from "react";
 import bus from "../lib/bus";
 
 export default function Topbar() {
   const ref = useRef<HTMLElement | null>(null);
+  const [theme, setTheme] = useState(() =>
+    localStorage.getItem("theme") || "dark"
+  );
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
 
   useLayoutEffect(() => {
     const el = ref.current!;
@@ -33,6 +41,15 @@ export default function Topbar() {
       <div className="topbar-title">superNova_2177</div>
 
       <div style={{ display: "flex", gap: 8 }}>
+        <button
+          className="topbar-menu-btn"
+          onClick={() =>
+            setTheme(theme === "dark" ? "light" : "dark")
+          }
+          aria-label="Toggle theme"
+        >
+          {theme === "dark" ? "☀️" : "🌙"}
+        </button>
         <button
           className="topbar-menu-btn"
           onClick={() => bus.emit("sidebar:toggle")}

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,12 +3,13 @@
    ========================= */
 *, *::before, *::after { box-sizing: border-box; }
 html, body, #root { height: 100%; }
-html, body { margin: 0; padding: 0; background: #07090f; color: #f2f4f8; }
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
 img, svg, video, canvas { display: block; max-width: 100%; }
 button, input, textarea, select { font: inherit; color: inherit; }
 :focus-visible { outline: 2px solid #0A84FF; outline-offset: 2px; }
 
 :root{
+  --bg: #07090f;
   --ink: #f2f4f8;
   --ink-2: #9aa3b2;
   --stroke-1: rgba(255,255,255,.06);
@@ -16,6 +17,7 @@ button, input, textarea, select { font: inherit; color: inherit; }
   --glass-base: rgba(14,16,22,.36);
   --glass: color-mix(in srgb, rgba(255,255,255,0.9) 40%, var(--glass-base) 60%);
   --glass-strong: color-mix(in srgb, rgba(255,255,255,0.95) 45%, var(--glass-base) 55%);
+  --shadow: 0 4px 12px rgba(0,0,0,0.5);
 
   --feed-max: min(100%, 1200px);
   --stripe-h: 64px;
@@ -24,6 +26,18 @@ button, input, textarea, select { font: inherit; color: inherit; }
   /* Theme accents */
   --pink: #ff74de;   /* Assistant orb theme */
   --blue: #4f7afe;   /* Brand/top-left orb theme */
+}
+
+:root[data-theme="light"] {
+  --bg: #f5f6f8;
+  --ink: #0b0d12;
+  --ink-2: #5b5f69;
+  --stroke-1: rgba(0,0,0,.06);
+  --stroke-2: rgba(0,0,0,.12);
+  --glass-base: rgba(255,255,255,.65);
+  --glass: color-mix(in srgb, rgba(255,255,255,0.8) 65%, var(--glass-base) 35%);
+  --glass-strong: color-mix(in srgb, rgba(255,255,255,0.9) 75%, var(--glass-base) 25%);
+  --shadow: 0 4px 12px rgba(0,0,0,0.08);
 }
 
 /* =========================
@@ -57,7 +71,8 @@ button, input, textarea, select { font: inherit; color: inherit; }
   background: var(--glass);
   -webkit-backdrop-filter: blur(14px) saturate(160%);
   backdrop-filter: blur(14px) saturate(160%);
-  border-bottom: 1px solid rgba(255,255,255,.06);
+  border-bottom: 1px solid var(--stroke-1);
+  box-shadow: var(--shadow);
 }
 .topbar-orb {
   position: relative;
@@ -78,9 +93,9 @@ button, input, textarea, select { font: inherit; color: inherit; }
 .topbar-title { font-weight: 900; letter-spacing: .3px; }
 .topbar-menu-btn {
   width: 40px; height: 40px; border-radius: 10px; cursor: pointer;
-  background: rgba(255,255,255,.08);
-  border: 1px solid rgba(255,255,255,.14);
-  color: #fff;
+  background: color-mix(in srgb, var(--ink) 10%, transparent);
+  border: 1px solid var(--stroke-2);
+  color: var(--ink);
 }
 
 /* =========================


### PR DESCRIPTION
## Summary
- add light/dark theme variables for semi-transparent glass look
- introduce topbar button to toggle themes
- ignore node_modules and build artifacts

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'style') in PostCard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689ebda43f38832189a1c1097f354526