### PR TITLE
feat: add motion animations

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import type { AssistantMessage, Post } from "../types";
 import RadialMenu from "./RadialMenu";
+import { motion, useReducedMotion } from "framer-motion";
 
 /**
  * Assistant Orb — circular quick menu + 60fps drag + voice.
@@ -86,6 +87,7 @@ export default function AssistantOrb() {
   const [dragging, setDragging] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false); // radial
   const [petal, setPetal] = useState<null | "comment" | "remix" | "share">(null);
+  const reduceMotion = useReducedMotion();
 
   // gestures
   const movedRef = useRef(false);
@@ -454,8 +456,6 @@ export default function AssistantOrb() {
   };
   const ringStyle: React.CSSProperties = {
     position: "absolute", inset: -6, borderRadius: 999, pointerEvents: "none",
-    boxShadow: mic ? "0 0 0 10px rgba(255,116,222,.16)" : "inset 0 0 24px rgba(255,255,255,.55)",
-    transition: "box-shadow .25s ease",
   };
   const toastBoxStyle: React.CSSProperties = {
     position: "fixed",
@@ -528,8 +528,18 @@ export default function AssistantOrb() {
         onMouseLeave={() => { if (!dragging) setMenuOpen(false); }}
         onKeyDown={handleOrbKeyDown}
       >
-        <div style={coreStyle} />
-        <div style={ringStyle} />
+        <motion.div
+          style={{ position: "relative", width: "100%", height: "100%" }}
+          animate={{ scale: reduceMotion ? 1 : menuOpen || mic ? 1.1 : 1 }}
+          transition={reduceMotion ? { duration: 0 } : { type: "spring", stiffness: 260, damping: 20 }}
+        >
+          <div style={coreStyle} />
+          <motion.div
+            style={ringStyle}
+            animate={{ boxShadow: mic ? "0 0 0 10px rgba(255,116,222,.16)" : "inset 0 0 24px rgba(255,255,255,.55)" }}
+            transition={{ duration: reduceMotion ? 0 : 0.25 }}
+          />
+        </motion.div>
       </button>
 
       {/* Radial menu */}

--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 interface RadialMenuProps {
   center: { x: number; y: number };
@@ -28,6 +29,7 @@ export default function RadialMenu({
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [step, setStep] = useState<"root" | "react" | "create">("root");
   const [index, setIndex] = useState(0);
+  const reduceMotion = useReducedMotion();
 
   useEffect(() => {
     menuRef.current?.focus();
@@ -126,7 +128,7 @@ export default function RadialMenu({
     const x = radius * Math.cos(rad) - 20;
     const y = radius * Math.sin(rad) - 20;
     return (
-      <button
+      <motion.button
         key={item.id}
         id={`assistant-menu-item-${item.id}`}
         role="menuitem"
@@ -136,8 +138,15 @@ export default function RadialMenu({
           ...rbtn,
           left: x,
           top: y,
-          boxShadow: active ? "0 0 0 2px #ff74de" : undefined,
         }}
+        initial={reduceMotion ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }}
+        animate={{
+          scale: 1,
+          opacity: 1,
+          boxShadow: active ? "0 0 0 2px #ff74de" : "none",
+        }}
+        exit={reduceMotion ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }}
+        transition={{ duration: reduceMotion ? 0 : 0.2 }}
         onClick={() => {
           if (item.next) {
             setStep(item.next);
@@ -148,7 +157,7 @@ export default function RadialMenu({
         }}
       >
         {item.icon}
-      </button>
+      </motion.button>
     );
   }
 
@@ -168,33 +177,48 @@ export default function RadialMenu({
       aria-activedescendant={`assistant-menu-item-${activeId}`}
       style={{ position: "fixed", left: center.x, top: center.y, width: 0, height: 0, zIndex: 9998 }}
     >
-      {step === "root" &&
-        rootItems.map((item, i) =>
-          renderItem(item, i, rootAngles[i], i === index, 74)
-        )}
-      {step !== "root" && (
-        <button
-          id="assistant-menu-item-back"
-          role="menuitem"
-          tabIndex={-1}
-          aria-label="Back"
-          style={{ ...rbtn, left: -20, top: -20 }}
-          onClick={() => {
-            setStep("root");
-            setIndex(0);
-          }}
-        >
-          ⬅️
-        </button>
+      {step === "root" && (
+        <AnimatePresence>
+          {rootItems.map((item, i) =>
+            renderItem(item, i, rootAngles[i], i === index, 74)
+          )}
+        </AnimatePresence>
       )}
-      {step === "react" &&
-        reactItems.map((item, i) =>
-          renderItem(item, i, reactAngles[i], i === index, 120)
+      <AnimatePresence>
+        {step !== "root" && (
+          <motion.button
+            id="assistant-menu-item-back"
+            role="menuitem"
+            tabIndex={-1}
+            aria-label="Back"
+            style={{ ...rbtn, left: -20, top: -20 }}
+            initial={reduceMotion ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={reduceMotion ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.2 }}
+            onClick={() => {
+              setStep("root");
+              setIndex(0);
+            }}
+          >
+            ⬅️
+          </motion.button>
         )}
-      {step === "create" &&
-        createItems.map((item, i) =>
-          renderItem(item, i, createAngles[i], i === index, 120)
-        )}
+      </AnimatePresence>
+      {step === "react" && (
+        <AnimatePresence>
+          {reactItems.map((item, i) =>
+            renderItem(item, i, reactAngles[i], i === index, 120)
+          )}
+        </AnimatePresence>
+      )}
+      {step === "create" && (
+        <AnimatePresence>
+          {createItems.map((item, i) =>
+            renderItem(item, i, createAngles[i], i === index, 120)
+          )}
+        </AnimatePresence>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- animate radial menu entries and exits with framer-motion and highlight active items
- scale and glow assistant orb when menu opens or mic activates while honoring reduced-motion

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'style'))*


------
https://chatgpt.com/codex/tasks/task_e_689ec63cf57c8321be1f3db0f9b82560