### PR TITLE
feat: guard topbar theme localStorage access

### DIFF
--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -4,12 +4,16 @@ import bus from "../lib/bus";
 export default function Topbar() {
   const ref = useRef<HTMLElement | null>(null);
   const [theme, setTheme] = useState(() =>
-    localStorage.getItem("theme") || "dark"
+    typeof window !== "undefined"
+      ? localStorage.getItem("theme") || "dark"
+      : "dark"
   );
 
   useEffect(() => {
-    document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("theme", theme);
+    if (typeof window !== "undefined") {
+      document.documentElement.setAttribute("data-theme", theme);
+      localStorage.setItem("theme", theme);
+    }
   }, [theme]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Summary
- prevent server-side localStorage access by checking `typeof window`
- default to dark theme when window is undefined

## Testing
- `npm test` *(fails: PostCard image carousel TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_689ec81672f48321a1906d641c8cae8e