### PR TITLE
Guard localStorage usage in Sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,15 +6,17 @@ type Keys = { openai?: string; anthropic?: string; perplexity?: string; stabilit
 
 function useLocal<T>(key: string, init: T) {
   const [v, setV] = useState<T>(() => {
+    if (typeof window === "undefined") return init;
     try {
-      const raw = localStorage.getItem(key);
+      const raw = window.localStorage.getItem(key);
       return raw ? (JSON.parse(raw) as T) : init;
-    } catch { 
-      return init; 
+    } catch {
+      return init;
     }
   });
-  useEffect(() => { 
-    try { localStorage.setItem(key, JSON.stringify(v)); } catch {} 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try { window.localStorage.setItem(key, JSON.stringify(v)); } catch {}
   }, [key, v]);
   return [v, setV] as const;
 }


### PR DESCRIPTION
## Summary
- avoid accessing localStorage when `window` is undefined in `useLocal`

## Testing
- `npm test` *(fails: PostCard image carousel > shows and navigates multiple images)*

------
https://chatgpt.com/codex/tasks/task_e_689ec8199ba4832187f9111d86213876