### PR TITLE
Guard localStorage access in imageProviders

### DIFF
--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -28,7 +28,10 @@ function getKey(name: string) {
   };
   const envKey = envMap[name];
   if (envKey) return envKey;
-  try { return JSON.parse(localStorage.getItem("sn.keys") || "{}")[name]; } catch { return undefined; }
+  if (typeof window !== "undefined" && window.localStorage) {
+    try { return JSON.parse(window.localStorage.getItem("sn.keys") || "{}")[name]; } catch { return undefined; }
+  }
+  return undefined;
 }
 
 /** PICSUM — no key needed */


### PR DESCRIPTION
## Summary
- Guard `getKey` against missing `window` or `localStorage`

## Testing
- `npm test` *(fails: PostCard image carousel shows and navigates multiple images)*

------
https://chatgpt.com/codex/tasks/task_e_689ec81f385c8321bad36ec57343874c