### PR TITLE
Guard PortalOrb localStorage access for SSR

### DIFF
--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -21,15 +21,20 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [menuIndex, setMenuIndex] = useState(0);
   const [pos, setPos] = useState<{ x: number; y: number }>(() => {
-    const saved = localStorage.getItem("orb-pos");
-    return saved ? JSON.parse(saved) : { x: 16, y: 16 };
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("orb-pos");
+      return saved ? JSON.parse(saved) : { x: 16, y: 16 };
+    }
+    return { x: 16, y: 16 };
   });
   const [dragging, setDragging] = useState(false);
   const lastTap = useRef<number>(0);
   const analyzeOverlay = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    localStorage.setItem("orb-pos", JSON.stringify(pos));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("orb-pos", JSON.stringify(pos));
+    }
     if (orbRef.current) {
       orbRef.current.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
     }


### PR DESCRIPTION
## Summary
- guard PortalOrb's localStorage usage with `typeof window` checks to prevent SSR errors
- default orb position when `window` is unavailable

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'style'))*

------
https://chatgpt.com/codex/tasks/task_e_689ec826817083219e5fc05239377c64