### PR TITLE
refactor: use hook for portal orb pointer events

### DIFF
--- a/src/hooks/usePointer.ts
+++ b/src/hooks/usePointer.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+export interface PointerHandlers {
+  onMove?: (e: PointerEvent) => void;
+  onUp?: (e: PointerEvent) => void;
+  onCancel?: (e: PointerEvent) => void;
+}
+
+export default function usePointer(
+  active: boolean,
+  handlers: PointerHandlers
+) {
+  const handlersRef = useRef(handlers);
+
+  useEffect(() => {
+    handlersRef.current = handlers;
+  }, [handlers]);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const handleMove = (e: PointerEvent) => handlersRef.current.onMove?.(e);
+    const handleUp = (e: PointerEvent) => handlersRef.current.onUp?.(e);
+    const handleCancel = (e: PointerEvent) => {
+      if (handlersRef.current.onCancel) {
+        handlersRef.current.onCancel(e);
+      } else {
+        handlersRef.current.onUp?.(e);
+      }
+    };
+
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    window.addEventListener("pointercancel", handleCancel);
+
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      window.removeEventListener("pointercancel", handleCancel);
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- consolidate pointer drag and long-press handling in `PortalOrb`
- add `usePointer` hook to manage pointer move and release listeners

## Testing
- `npm test` *(fails: PostCard image carousel > shows and navigates multiple images)*

------
https://chatgpt.com/codex/tasks/task_e_689ec80398448321924d0915a21983c9