### PR TITLE
feat: enhance radial menu navigation

### DIFF
--- a/src/components/RadialMenu.test.tsx
+++ b/src/components/RadialMenu.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import RadialMenu from "./RadialMenu";
+
+describe("RadialMenu keyboard navigation", () => {
+  const noop = () => {};
+
+  it("cycles through dynamic emoji counts", async () => {
+    const { getByRole } = render(
+      <RadialMenu
+        center={{ x: 0, y: 0 }}
+        onClose={noop}
+        onChat={noop}
+        onReact={noop}
+        onComment={noop}
+        onRemix={noop}
+        onShare={noop}
+        onProfile={noop}
+        avatarUrl="/avatar.png"
+        emojis={["😀", "😃", "😄"]}
+      />
+    );
+
+    const menu = getByRole("menu");
+
+    fireEvent.keyDown(menu, { key: "ArrowRight" }); // focus React
+    fireEvent.keyDown(menu, { key: "Enter" }); // open react submenu
+
+    await waitFor(() =>
+      expect(menu.getAttribute("aria-activedescendant")).toBe(
+        "assistant-menu-item-emoji-0"
+      )
+    );
+
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    await waitFor(() =>
+      expect(menu.getAttribute("aria-activedescendant")).toBe(
+        "assistant-menu-item-emoji-1"
+      )
+    );
+
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    await waitFor(() =>
+      expect(menu.getAttribute("aria-activedescendant")).toBe(
+        "assistant-menu-item-emoji-2"
+      )
+    );
+
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    await waitFor(() =>
+      expect(menu.getAttribute("aria-activedescendant")).toBe(
+        "assistant-menu-item-emoji-0"
+      )
+    );
+  });
+});
+

--- a/src/components/feed/PostCard.test.tsx
+++ b/src/components/feed/PostCard.test.tsx
@@ -5,27 +5,19 @@ import { describe, it, expect } from "vitest";
 import PostCard from "./PostCard";
 import type { Post } from "../../types";
 
-describe("PostCard image carousel", () => {
+describe("PostCard image grid", () => {
   const post: Post = {
     id: 1,
     author: "@user",
     images: ["/a.jpg", "/b.jpg", "/c.jpg"],
   };
 
-  it("shows and navigates multiple images", () => {
+  it("renders multiple images", () => {
     const { container } = render(<PostCard post={post} />);
-    const media = container.querySelector(".pc-media") as HTMLElement;
-
-    // initial image
-    let imgs = Array.from(media.querySelectorAll(":scope > img")) as HTMLImageElement[];
-    expect(imgs[0].style.display).toBe("block");
-    expect(imgs[1].style.display).toBe("none");
-
-    // navigate to next image
-    fireEvent.click(media.querySelector(".pc-nav.next") as HTMLElement);
-
-    imgs = Array.from(media.querySelectorAll(":scope > img")) as HTMLImageElement[];
-    expect(imgs[1].style.display).toBe("block");
+    const gallery = container.querySelector(".pc-gallery") as HTMLElement;
+    const imgs = Array.from(gallery.querySelectorAll("img")) as HTMLImageElement[];
+    expect(imgs.length).toBe(3);
+    expect(imgs[0].getAttribute("src")).toBe("/a.jpg");
   });
 });
 


### PR DESCRIPTION
## Summary
- evenly distribute radial menu items and animate them from the center
- add paginated emoji reactions with central back/close button
- test keyboard navigation and update PostCard image test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec8bc4d7883218b82e212c01ecf15