### PR TITLE
Fix cleanup handler in AssistantOrb useEffect

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -110,7 +110,7 @@ export default function AssistantOrb() {
   useEffect(() => {
     const a = bus.on?.("feed:hover", (p: { post: Post }) => setCtxPost(p.post));
     const b = bus.on?.("feed:select", (p: { post: Post }) => setCtxPost(p.post));
-    return () => { try { a?.(); } catch {} try { b?.(); } catch {} };
+    return () => { try { a?.(); } catch {}; try { b?.(); } catch {}; };
   }, []);
 
   // speech


### PR DESCRIPTION
## Summary
- ensure bus subscriptions in `AssistantOrb` cleanup independently

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'style'))*

------
https://chatgpt.com/codex/tasks/task_e_689ec8285f308321b77eff70800792ed