### PR TITLE
Guard share button clipboard usage

### DIFF
--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -187,8 +187,21 @@ export default function PostCard({ post }: { post: Post }) {
               title="Share"
               aria-label="Share"
               onClick={async () => {
-                const url = `${location.origin}${location.pathname}#post-${post.id}`;
-                try { await navigator.clipboard.writeText(url); } catch {}
+                if (
+                  typeof location !== "undefined" &&
+                  typeof navigator !== "undefined" &&
+                  typeof navigator.clipboard !== "undefined" &&
+                  typeof navigator.clipboard.writeText === "function"
+                ) {
+                  const url = `${location.origin}${location.pathname}#post-${post.id}`;
+                  try {
+                    await navigator.clipboard.writeText(url);
+                  } catch {}
+                } else {
+                  try {
+                    console.warn?.("Clipboard not available");
+                  } catch {}
+                }
               }}
             >
               <span className="ico share" />


### PR DESCRIPTION
## Summary
- Guard share button copy logic with `typeof` checks for `location` and `navigator.clipboard`
- Warn when Clipboard API is unavailable instead of throwing

## Testing
- `npm test` *(fails: TypeError in PostCard image carousel test)*

------
https://chatgpt.com/codex/tasks/task_e_689ec8353c988321a197c74f29d9560a