### PR TITLE
feat: load initial page on mount for infinite scroll hook

### DIFF
--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -18,6 +18,28 @@ export function useInfiniteScroll<T>(opts: {
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (items.length !== 0) return;
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const next = await loadMore();
+        if (!cancelled) {
+          setItems((prev) => prev.concat(next));
+          setPage((p) => p + 1);
+        }
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message || "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     let cancelled = false;
     const io = new IntersectionObserver(async (entries) => {
       const e = entries[0];


### PR DESCRIPTION
## Summary
- trigger loadMore on mount when no items are present

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'style'))*

------
https://chatgpt.com/codex/tasks/task_e_689ec840023483219f03b13ac5c02377