### PR TITLE
Clear PortalOverlay timeout on cleanup

### DIFF
--- a/src/components/PortalOverlay.tsx
+++ b/src/components/PortalOverlay.tsx
@@ -5,16 +5,21 @@ import bus from "../lib/bus";
 export default function PortalOverlay(){
   const ref = useRef<HTMLDivElement|null>(null);
   const [on, setOn] = useState(false);
+  let timer: number | null = null;
 
   useEffect(() => {
-    return bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
+    const off = bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
       const el = ref.current;
       if (!el) return;
       el.style.setProperty("--px", `${x}px`);
       el.style.setProperty("--py", `${y}px`);
       setOn(true);
-      window.setTimeout(() => setOn(false), 700);
+      timer = window.setTimeout(() => setOn(false), 700);
     });
+    return () => {
+      if (timer) clearTimeout(timer);
+      off();
+    };
   }, []);
 
   return <div ref={ref} className={`portal-overlay${on ? " on": ""}`} />;


### PR DESCRIPTION
## Summary
- track timeout ID for PortalOverlay and clear it during effect cleanup

## Testing
- `npm test` *(fails: PostCard image carousel > shows and navigates multiple images)*

------
https://chatgpt.com/codex/tasks/task_e_689ec858981083218ad28345102369f3