### PR TITLE
feat: toggle assistant menu via click

### DIFF
--- a/src/components/AssistantOrb.test.tsx
+++ b/src/components/AssistantOrb.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import AssistantOrb from "./AssistantOrb";
+
+describe("AssistantOrb menu interactions", () => {
+  it("opens via click or keyboard and closes on outside click or Escape", async () => {
+    const { getByRole, queryByRole } = render(<AssistantOrb />);
+
+    const orb = getByRole("button", { name: /assistant orb/i });
+
+    // Hover shouldn't open the menu
+    fireEvent.mouseEnter(orb);
+    expect(queryByRole("menu")).toBeNull();
+
+    // Click opens the menu
+    fireEvent.click(orb);
+    await waitFor(() => expect(queryByRole("menu")).not.toBeNull());
+
+    // Outside click closes the menu
+    fireEvent.pointerDown(document.body);
+    await waitFor(() => expect(queryByRole("menu")).toBeNull());
+
+    // Keyboard activation opens the menu
+    fireEvent.keyDown(orb, { key: "Enter" });
+    await waitFor(() => expect(queryByRole("menu")).not.toBeNull());
+
+    // Escape closes the menu
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(queryByRole("menu")).toBeNull());
+  });
+});
+

--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -401,6 +401,25 @@ export default function AssistantOrb() {
   useEffect(() => { if (msgListRef.current) msgListRef.current.scrollTop = msgListRef.current.scrollHeight; }, [msgs]);
 
   useEffect(() => {
+    if (!menuOpen) return;
+    const handlePointerDown = (e: PointerEvent) => {
+      const menuEl = document.querySelector('[role="menu"]');
+      if (orbRef.current?.contains(e.target as Node)) return;
+      if (menuEl?.contains(e.target as Node)) return;
+      setMenuOpen(false);
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
     const onResize = () => {
       if (typeof window === "undefined") return;
       const nx = clamp(posRef.current.x, ORB_MARGIN, window.innerWidth - ORB_SIZE - ORB_MARGIN);
@@ -524,8 +543,6 @@ export default function AssistantOrb() {
         onLostPointerCapture={onLostPointerCapture}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
-        onMouseEnter={() => { setMenuOpen(true); requestAnimationFrame(updateAnchors); }}
-        onMouseLeave={() => { if (!dragging) setMenuOpen(false); }}
         onKeyDown={handleOrbKeyDown}
       >
         <motion.div


### PR DESCRIPTION
## Summary
- open AssistantOrb menu only on click or keyboard activation
- add document listeners to close orb menu on outside click or Escape
- test menu open/close interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eca4e05ec8321840d8c674ba56bb2