### PR TITLE
Handle model-viewer script load errors

### DIFF
--- a/src/lib/ensureModelViewer.ts
+++ b/src/lib/ensureModelViewer.ts
@@ -6,12 +6,16 @@ export function ensureModelViewer(): Promise<void> {
   if (customElements.get("model-viewer")) return Promise.resolve();
   if (loading) return loading;
 
-  loading = new Promise<void>((resolve) => {
+  loading = new Promise<void>((resolve, reject) => {
     const script = document.createElement("script");
     script.type = "module";
     script.src =
       "https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js";
     script.onload = () => resolve();
+    script.onerror = (err) => {
+      loading = null;
+      reject(err instanceof Error ? err : new Error("Failed to load model-viewer"));
+    };
     document.head.appendChild(script);
   });
 


### PR DESCRIPTION
## Summary
- allow `ensureModelViewer` to reject when script fails to load
- reset `loading` to null on load errors so callers can retry

## Testing
- `npm test` *(fails: PostCard image carousel test cannot read property 'style')*

------
https://chatgpt.com/codex/tasks/task_e_689ec8559c048321b602d579e9c85c33