### PR TITLE
Guard document usage in share fallback

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -60,20 +60,23 @@ export async function sharePost(arg: Post | ShareOptions | string): Promise<bool
   }
 
   // Legacy execCommand fallback
-  const ta = document.createElement("textarea");
-  try {
-    ta.value = url;
-    ta.style.position = "fixed";
-    ta.style.opacity = "0";
-    document.body.appendChild(ta);
-    ta.select();
-    document.execCommand("copy");
-    return true;
-  } catch {
-    return false;
-  } finally {
-    document.body.removeChild(ta);
+  if (typeof document !== "undefined") {
+    const ta = document.createElement("textarea");
+    try {
+      ta.value = url;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      return true;
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(ta);
+    }
   }
+  return false;
 }
 
 export default sharePost;


### PR DESCRIPTION
## Summary
- Guard legacy clipboard fallback against missing `document`
- Return `false` when `document` is undefined instead of crashing

## Testing
- `npm test` *(fails: PostCard image carousel > shows and navigates multiple images)*

------
https://chatgpt.com/codex/tasks/task_e_689ec851e2a88321aaa0e1e5c183d18e