### PR TITLE
Emit compose event from PortalOrb and document action

### DIFF
--- a/src/components/PortalOrb.test.tsx
+++ b/src/components/PortalOrb.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import PortalOrb from "./PortalOrb";
+import bus from "../lib/bus";
+
+describe("PortalOrb compose action", () => {
+  it("emits compose event when selecting compose", async () => {
+    const emitSpy = vi.spyOn(bus, "emit");
+    const { getByRole, findByTitle } = render(
+      <PortalOrb onAnalyzeImage={() => {}} />
+    );
+    const orb = getByRole("button", { name: /ai portal/i });
+    fireEvent.keyDown(orb, { key: "Enter" });
+    const composeBtn = await findByTitle("Compose");
+    fireEvent.click(composeBtn);
+    expect(emitSpy).toHaveBeenCalledWith("compose");
+    emitSpy.mockRestore();
+  });
+});

--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import usePointer from "../hooks/usePointer";
+import bus from "../lib/bus";
 
 type Props = {
   onAnalyzeImage: (imgUrl: string) => void;
@@ -202,10 +203,10 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
       ),
       label: "Compose",
       callback: () => {
+        setMode("idle");
         setMenuOpen(false);
         orbRef.current?.classList.remove("grow");
-        // placeholder “compose” action
-        alert("Compose: hook this to your AI API.");
+        bus.emit("compose");
       },
     },
     {


### PR DESCRIPTION
## Summary
- replace placeholder alert in PortalOrb with bus.emit("compose") and reset state
- cover compose action with a new PortalOrb test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eccaf616c8321bba8e2eb1a12688b