### PR TITLE
Handle provider fetch errors gracefully

### DIFF
--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -34,20 +34,24 @@ function getKey(name: string) {
 /** PICSUM — no key needed */
 async function fetchPicsum(page: number, perPage: number): Promise<FeedImage[]> {
   const url = `https://picsum.photos/v2/list?page=${page}&limit=${perPage}`;
-  const res = await fetch(url);
-  const list = await res.json() as any[];
-  return list.map((x) => {
-    const w = 1200;
-    // height scaled to maintain aspect; picsum endpoint takes fixed w/h; we’ll let browser scale
-    return {
-      id: String(x.id),
-      src: `https://picsum.photos/id/${x.id}/${w}/800`,
-      thumb: `https://picsum.photos/id/${x.id}/200/140`,
-      author: x.author,
-      link: x.url,
-      width: x.width, height: x.height,
-    } as FeedImage;
-  });
+  try {
+    const res = await fetch(url);
+    const list = (await res.json()) as any[];
+    return list.map((x) => {
+      const w = 1200;
+      // height scaled to maintain aspect; picsum endpoint takes fixed w/h; we’ll let browser scale
+      return {
+        id: String(x.id),
+        src: `https://picsum.photos/id/${x.id}/${w}/800`,
+        thumb: `https://picsum.photos/id/${x.id}/200/140`,
+        author: x.author,
+        link: x.url,
+        width: x.width, height: x.height,
+      } as FeedImage;
+    });
+  } catch {
+    return [];
+  }
 }
 
 /** UNSPLASH (optional) — needs access key (store as localStorage.sn.keys.unsplash) */
@@ -61,17 +65,21 @@ async function fetchUnsplash(page: number, perPage: number, query?: string): Pro
     orientation: "landscape",
     query: query || "",
   });
-  const res = await fetch(`${base}?${params.toString()}`, { headers: { Authorization: `Client-ID ${key}` } });
-  const json = await res.json();
-  const items = query ? (json.results || []) : json;
-  return items.map((x: any) => ({
-    id: x.id,
-    src: x.urls?.regular || x.urls?.full,
-    thumb: x.urls?.small,
-    author: x.user?.name,
-    link: x.links?.html,
-    width: x.width, height: x.height,
-  } as FeedImage));
+  try {
+    const res = await fetch(`${base}?${params.toString()}`, { headers: { Authorization: `Client-ID ${key}` } });
+    const json = await res.json();
+    const items = query ? (json.results || []) : json;
+    return items.map((x: any) => ({
+      id: x.id,
+      src: x.urls?.regular || x.urls?.full,
+      thumb: x.urls?.small,
+      author: x.user?.name,
+      link: x.links?.html,
+      width: x.width, height: x.height,
+    } as FeedImage));
+  } catch {
+    return [];
+  }
 }
 
 /** PEXELS (optional) — needs key (store as localStorage.sn.keys.pexels) */
@@ -84,17 +92,21 @@ async function fetchPexels(page: number, perPage: number, query?: string): Promi
     per_page: String(perPage),
     query: query || "",
   });
-  const res = await fetch(`${base}?${params.toString()}`, { headers: { Authorization: key } });
-  const json = await res.json();
-  const items = json.photos || [];
-  return items.map((x: any) => ({
-    id: String(x.id),
-    src: x.src?.large2x || x.src?.large || x.src?.original,
-    thumb: x.src?.tiny || x.src?.small,
-    author: x.photographer,
-    link: x.url,
-    width: x.width, height: x.height,
-  } as FeedImage));
+  try {
+    const res = await fetch(`${base}?${params.toString()}`, { headers: { Authorization: key } });
+    const json = await res.json();
+    const items = json.photos || [];
+    return items.map((x: any) => ({
+      id: String(x.id),
+      src: x.src?.large2x || x.src?.large || x.src?.original,
+      thumb: x.src?.tiny || x.src?.small,
+      author: x.photographer,
+      link: x.url,
+      width: x.width, height: x.height,
+    } as FeedImage));
+  } catch {
+    return [];
+  }
 }
 
 /** Main entry */


### PR DESCRIPTION
## Summary
- Wrap image provider fetches in try/catch and return empty arrays on failure

## Testing
- `npm test` *(fails: PostCard image carousel > shows and navigates multiple images)*

------
https://chatgpt.com/codex/tasks/task_e_689ec8484fd883219495ae57c4e496c2