### PR TITLE
feat: use contextual alt text for post images

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -61,7 +61,7 @@ export default function PostCard({ post, onOpenProfile, onEnterWorld }: Props) {
         ) : (
           <img
             src={img || mediaFallback}
-            alt=""
+            alt={post.title ?? post.author ?? "post image"}
             loading="lazy"
             onLoad={onMediaReady}
           />


### PR DESCRIPTION
## Summary
- ensure PostCard image alt attribute uses post title or author when available

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'style') in src/components/feed/PostCard.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689ec84c2cc88321b12750c9f2fad465