### PR TITLE
Add animated radial menu buttons

### DIFF
--- a/src/components/RadialMenu.css
+++ b/src/components/RadialMenu.css
@@ -1,0 +1,20 @@
+.rbtn {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border-radius: 9999px;
+  display: grid;
+  place-items: center;
+  background: rgba(14, 16, 22, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+  cursor: pointer;
+  backdrop-filter: blur(8px) saturate(140%);
+  transform-origin: center;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.rbtn:hover {
+  background: rgba(14, 16, 22, 0.85);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
+}

--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import "./RadialMenu.css";
 
 interface RadialMenuProps {
   center: { x: number; y: number };
@@ -131,20 +132,6 @@ export default function RadialMenu({
     }
   }
 
-  const rbtn: React.CSSProperties = {
-    position: "absolute",
-    width: 40,
-    height: 40,
-    borderRadius: 999,
-    display: "grid",
-    placeItems: "center",
-    background: "rgba(14,16,22,.7)",
-    border: "1px solid rgba(255,255,255,.15)",
-    color: "#fff",
-    cursor: "pointer",
-    backdropFilter: "blur(8px) saturate(140%)",
-  };
-
   const angleFor = (i: number, len: number) => (360 / len) * i - 90;
 
   function renderItem(
@@ -164,29 +151,30 @@ export default function RadialMenu({
         role="menuitem"
         tabIndex={-1}
         aria-label={item.label}
-        style={{
-          ...rbtn,
-          left: -20,
-          top: -20,
-        }}
+        className="rbtn"
+        style={{ left: -20, top: -20 }}
         initial={
           reduceMotion
-            ? { scale: 1, opacity: 1, x, y }
-            : { scale: 0, opacity: 0, x: 0, y: 0 }
+            ? { opacity: 1, x, y, scale: 1 }
+            : { opacity: 0, x: 0, y: 0, scale: 0 }
         }
         animate={{
-          scale: 1,
           opacity: 1,
           x,
           y,
+          scale: 1,
           boxShadow: active ? "0 0 0 2px #ff74de" : "none",
         }}
         exit={
           reduceMotion
-            ? { scale: 1, opacity: 1, x, y }
-            : { scale: 0, opacity: 0, x: 0, y: 0 }
+            ? { opacity: 1, x, y, scale: 1 }
+            : { opacity: 0, x: 0, y: 0, scale: 0 }
         }
-        transition={{ duration: reduceMotion ? 0 : 0.2 }}
+        transition={{
+          duration: reduceMotion ? 0 : 0.25,
+          ease: [0.4, 0, 0.2, 1],
+        }}
+        whileHover={reduceMotion ? undefined : { scale: 1.1 }}
         onClick={() => {
           if (item.next) {
             setStep(item.next);
@@ -226,11 +214,16 @@ export default function RadialMenu({
           role="menuitem"
           tabIndex={-1}
           aria-label={step === "root" ? "Close" : "Back"}
-          style={{ ...rbtn, left: -20, top: -20 }}
-          initial={reduceMotion ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }}
-          animate={{ scale: 1, opacity: 1 }}
-          exit={reduceMotion ? { scale: 1, opacity: 1 } : { scale: 0, opacity: 0 }}
-          transition={{ duration: reduceMotion ? 0 : 0.2 }}
+          className="rbtn"
+          style={{ left: -20, top: -20 }}
+          initial={reduceMotion ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={reduceMotion ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0 }}
+          transition={{
+            duration: reduceMotion ? 0 : 0.25,
+            ease: [0.4, 0, 0.2, 1],
+          }}
+          whileHover={reduceMotion ? undefined : { scale: 1.1 }}
           onClick={() => {
             if (step === "root") {
               onClose();


### PR DESCRIPTION
## Summary
- style radial menu buttons with new `.rbtn` class and hover effects
- animate radial items to scale and fade from the center on mount/unmount

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ecee0dbb88321b9d77378af77e876