### PR TITLE
feat: adapt radial menu to viewport edges

### DIFF
--- a/src/components/RadialMenu.test.tsx
+++ b/src/components/RadialMenu.test.tsx
@@ -7,7 +7,7 @@ describe("RadialMenu keyboard navigation", () => {
   const noop = () => {};
 
   it("cycles through dynamic emoji counts", async () => {
-    const { getByRole } = render(
+    const { getAllByRole } = render(
       <RadialMenu
         center={{ x: 0, y: 0 }}
         onClose={noop}
@@ -22,7 +22,7 @@ describe("RadialMenu keyboard navigation", () => {
       />
     );
 
-    const menu = getByRole("menu");
+    const menu = getAllByRole("menu")[0];
 
     fireEvent.keyDown(menu, { key: "ArrowRight" }); // focus React
     fireEvent.keyDown(menu, { key: "Enter" }); // open react submenu
@@ -53,6 +53,29 @@ describe("RadialMenu keyboard navigation", () => {
         "assistant-menu-item-emoji-0"
       )
     );
+  });
+
+  it("offsets when near viewport edge", async () => {
+    const { getAllByRole } = render(
+      <RadialMenu
+        center={{ x: 0, y: 0 }}
+        onClose={noop}
+        onChat={noop}
+        onReact={noop}
+        onComment={noop}
+        onRemix={noop}
+        onShare={noop}
+        onProfile={noop}
+        avatarUrl="/avatar.png"
+        emojis={["😀", "😃", "😄"]}
+      />
+    );
+
+    const menu = getAllByRole("menu")[0];
+    await waitFor(() => {
+      expect(parseInt(menu.style.left, 10)).toBeGreaterThan(0);
+      expect(parseInt(menu.style.top, 10)).toBeGreaterThan(0);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- compute menu item angles from count and allow viewport-based rotation
- clamp radial menu position to keep buttons on screen
- test menu position adjustment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ecedb216c8321a858c11ef5a9fd1c