### PR TITLE
feat: add nested radial menu support

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import type { AssistantMessage, Post } from "../types";
-import RadialMenu from "./RadialMenu";
+import RadialMenu, { RadialMenuItem } from "./RadialMenu";
 import { motion, useReducedMotion } from "framer-motion";
 
 /**
@@ -584,41 +584,79 @@ export default function AssistantOrb() {
               orbRef.current?.focus();
             }}
           />
-          <RadialMenu
-            center={{ x: pos.x + ORB_SIZE / 2, y: pos.y + ORB_SIZE / 2 }}
-            onClose={() => {
-              setMenuOpen(false);
-              orbRef.current?.focus();
-            }}
-            onChat={() => {
-              setOpen(v => !v);
-              setPetal(null);
-              setMenuOpen(false);
-              requestAnimationFrame(updateAnchors);
-            }}
-            onReact={(e) => {
-              handleEmojiClick(e);
-              setMenuOpen(false);
-            }}
-            onComment={() => {
-              setPetal("comment");
-              setMenuOpen(false);
-            }}
-            onRemix={() => {
-              setPetal("remix");
-              setMenuOpen(false);
-            }}
-            onShare={() => {
-              setPetal("share");
-              setMenuOpen(false);
-            }}
-            onProfile={() => {
-              if (ctxPost) bus.emit?.("profile:open", { id: ctxPost.author });
-              setMenuOpen(false);
-            }}
-            avatarUrl={ctxPost?.authorAvatar || "/avatar.jpg"}
-            emojis={EMOJI_LIST.slice(0, 8)}
-          />
+          {(() => {
+            const emojis = EMOJI_LIST.slice(0, 8);
+            const reactItems: RadialMenuItem[] = emojis.map((e, i) => ({
+              id: `emoji-${i}`,
+              label: `React ${e}`,
+              icon: e,
+              action: () => {
+                handleEmojiClick(e);
+              },
+            }));
+            const items: RadialMenuItem[] = [
+              {
+                id: "chat",
+                label: "Chat",
+                icon: "💬",
+                action: () => {
+                  setOpen((v) => !v);
+                  setPetal(null);
+                  requestAnimationFrame(updateAnchors);
+                },
+              },
+              { id: "react", label: "React", icon: "👏", items: reactItems },
+              {
+                id: "compose",
+                label: "Compose",
+                icon: "✍️",
+                items: [
+                  {
+                    id: "comment",
+                    label: "Comment",
+                    icon: "✍️",
+                    action: () => setPetal("comment"),
+                  },
+                  {
+                    id: "remix",
+                    label: "Remix",
+                    icon: "🎬",
+                    action: () => setPetal("remix"),
+                  },
+                  {
+                    id: "share",
+                    label: "Share",
+                    icon: "↗️",
+                    action: () => setPetal("share"),
+                  },
+                ],
+              },
+              {
+                id: "profile",
+                label: "Profile",
+                icon: (
+                  <img
+                    src={ctxPost?.authorAvatar || "/avatar.jpg"}
+                    alt=""
+                    style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  />
+                ),
+                action: () => {
+                  if (ctxPost) bus.emit?.("profile:open", { id: ctxPost.author });
+                },
+              },
+            ];
+            return (
+              <RadialMenu
+                center={{ x: pos.x + ORB_SIZE / 2, y: pos.y + ORB_SIZE / 2 }}
+                onClose={() => {
+                  setMenuOpen(false);
+                  orbRef.current?.focus();
+                }}
+                items={items}
+              />
+            );
+          })()}
         </>
       )}
 

--- a/src/components/PortalOrb.test.tsx
+++ b/src/components/PortalOrb.test.tsx
@@ -5,16 +5,18 @@ import PortalOrb from "./PortalOrb";
 import bus from "../lib/bus";
 
 describe("PortalOrb compose action", () => {
-  it("emits compose event when selecting compose", async () => {
+  it("emits compose:comment when selecting comment", async () => {
     const emitSpy = vi.spyOn(bus, "emit");
-    const { getByRole, findByTitle } = render(
+    const { getByRole, findByLabelText } = render(
       <PortalOrb onAnalyzeImage={() => {}} />
     );
     const orb = getByRole("button", { name: /ai portal/i });
     fireEvent.keyDown(orb, { key: "Enter" });
-    const composeBtn = await findByTitle("Compose");
+    const composeBtn = await findByLabelText("Compose");
     fireEvent.click(composeBtn);
-    expect(emitSpy).toHaveBeenCalledWith("compose");
+    const commentBtn = await findByLabelText("Comment");
+    fireEvent.click(commentBtn);
+    expect(emitSpy).toHaveBeenCalledWith("compose:comment");
     emitSpy.mockRestore();
   });
 });

--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import usePointer from "../hooks/usePointer";
 import bus from "../lib/bus";
+import RadialMenu, { RadialMenuItem } from "./RadialMenu";
 
 type Props = {
   onAnalyzeImage: (imgUrl: string) => void;
@@ -19,9 +20,6 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   const originRef = useRef({ x: 0, y: 0 });
   const [mode, setMode] = useState<Mode>("idle");
   const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const [menuIndex, setMenuIndex] = useState(0);
   const [pos, setPos] = useState<{ x: number; y: number }>(() => {
     if (typeof window !== "undefined") {
       const saved = localStorage.getItem("orb-pos");
@@ -166,8 +164,10 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
     analyzeOverlay.current = null;
   }
 
-  const actions: { icon: React.ReactNode; label: string; callback: () => void }[] = [
+  const menuItems: RadialMenuItem[] = [
     {
+      id: "analyze",
+      label: "Analyze",
       icon: (
         <svg viewBox="0 0 24 24" className="ico">
           <path
@@ -187,10 +187,12 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
           />
         </svg>
       ),
-      label: "Analyze",
-      callback: startAnalyze,
+      action: startAnalyze,
+      closeOnSelect: false,
     },
     {
+      id: "compose",
+      label: "Compose",
       icon: (
         <svg className="ico" viewBox="0 0 24 24">
           <path
@@ -201,15 +203,30 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
           />
         </svg>
       ),
-      label: "Compose",
-      callback: () => {
-        setMode("idle");
-        setMenuOpen(false);
-        orbRef.current?.classList.remove("grow");
-        bus.emit("compose");
-      },
+      items: [
+        {
+          id: "comment",
+          label: "Comment",
+          icon: "✍️",
+          action: () => bus.emit("compose:comment"),
+        },
+        {
+          id: "remix",
+          label: "Remix",
+          icon: "🎬",
+          action: () => bus.emit("compose:remix"),
+        },
+        {
+          id: "share",
+          label: "Share",
+          icon: "↗️",
+          action: () => bus.emit("compose:share"),
+        },
+      ],
     },
     {
+      id: "close",
+      label: "Close",
       icon: (
         <svg className="ico" viewBox="0 0 24 24">
           <path
@@ -219,8 +236,7 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
           />
         </svg>
       ),
-      label: "Close",
-      callback: () => {
+      action: () => {
         setMode("idle");
         setMenuOpen(false);
         orbRef.current?.classList.remove("grow");
@@ -241,39 +257,6 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
       orbRef.current?.classList.remove("grow");
     }
   }
-
-  function handleMenuKey(e: React.KeyboardEvent) {
-    const items = itemRefs.current.filter(Boolean) as HTMLButtonElement[];
-    if (!items.length) return;
-    if (e.key === "ArrowRight" || e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
-      e.preventDefault();
-      const next = (menuIndex + 1) % items.length;
-      setMenuIndex(next);
-      items[next]?.focus();
-    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
-      e.preventDefault();
-      const next = (menuIndex - 1 + items.length) % items.length;
-      setMenuIndex(next);
-      items[next]?.focus();
-    } else if (e.key === "Escape") {
-      setMenuOpen(false);
-      setMode("idle");
-      orbRef.current?.focus();
-    } else if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      items[menuIndex]?.click();
-    }
-  }
-
-  useEffect(() => {
-    if (menuOpen) {
-      setMenuIndex(0);
-      const first = itemRefs.current[0];
-      first?.focus();
-    } else {
-      itemRefs.current = [];
-    }
-  }, [menuOpen]);
 
   usePointer(dragging, {
     onMove: handlePointerMove,
@@ -301,47 +284,15 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
         <div className="orb-core" />
         {/* radial menu */}
         {menuOpen && (
-          <div
-            className="radial-menu"
-            role="menu"
-            aria-label="Portal actions"
-            ref={menuRef}
-            onKeyDown={handleMenuKey}
-            aria-activedescendant={`portal-orb-item-${menuIndex}`}
-          >
-            {actions.map((action, i) => {
-              const angle = (360 / actions.length) * i - 90;
-              const rad = (angle * Math.PI) / 180;
-              const iconX = 94 * Math.cos(rad);
-              const iconY = 94 * Math.sin(rad);
-              const labelX = 140 * Math.cos(rad);
-              const labelY = 140 * Math.sin(rad);
-              return (
-                <React.Fragment key={action.label}>
-                  <button
-                    className="rm-item"
-                    onClick={action.callback}
-                    title={action.label}
-                    role="menuitem"
-                    ref={(el) => (itemRefs.current[i] = el)}
-                    tabIndex={menuIndex === i ? 0 : -1}
-                    id={`portal-orb-item-${i}`}
-                    style={{ transform: `translate(${iconX}px, ${iconY}px)` }}
-                  >
-                    {action.icon}
-                  </button>
-                  <span
-                    className="rm-label"
-                    style={{
-                      transform: `translate(${labelX}px, ${labelY}px) translate(-50%, -50%)`,
-                    }}
-                  >
-                    {action.label}
-                  </span>
-                </React.Fragment>
-              );
-            })}
-          </div>
+          <RadialMenu
+            center={{ x: pos.x + 32, y: pos.y + 32 }}
+            onClose={() => {
+              setMode("idle");
+              setMenuOpen(false);
+              orbRef.current?.classList.remove("grow");
+            }}
+            items={menuItems}
+          />
         )}
       </div>
 
@@ -381,20 +332,6 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
         }
         @keyframes spin{ to{ filter:hue-rotate(90deg) saturate(1.3) } }
 
-        .radial-menu{
-          position:absolute;inset:-30px;display:grid;place-items:center;pointer-events:none;
-        }
-        .rm-item{
-          position:absolute;pointer-events:auto;
-          display:grid;place-items:center;gap:6px;padding:6px 8px;background:rgba(16,18,24,.9);
-          border:1px solid var(--stroke-2);color:#fff;
-        }
-        .rm-item .ico{width:18px;height:18px}
-        .rm-label{
-          position:absolute;pointer-events:none;
-          padding:2px 4px;background:rgba(16,18,24,.9);
-          border:1px solid var(--stroke-2);color:#fff;font-size:12px;
-        }
         .analyzing .orb-core{ box-shadow:0 0 0 1px rgba(255,255,255,.08) inset, 0 10px 70px rgba(10,132,255,.7) }
       `}</style>
     </>

--- a/src/components/RadialMenu.test.tsx
+++ b/src/components/RadialMenu.test.tsx
@@ -1,30 +1,28 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
-import RadialMenu from "./RadialMenu";
+import RadialMenu, { RadialMenuItem } from "./RadialMenu";
 
 describe("RadialMenu keyboard navigation", () => {
   const noop = () => {};
 
   it("cycles through dynamic emoji counts", async () => {
+    const emojis = ["😀", "😃", "😄"];
+    const reactItems: RadialMenuItem[] = emojis.map((e, i) => ({
+      id: `emoji-${i}`,
+      label: e,
+      icon: e,
+      action: noop,
+    }));
+    const items: RadialMenuItem[] = [
+      { id: "react", label: "React", icon: "👏", items: reactItems },
+    ];
     const { getByRole } = render(
-      <RadialMenu
-        center={{ x: 0, y: 0 }}
-        onClose={noop}
-        onChat={noop}
-        onReact={noop}
-        onComment={noop}
-        onRemix={noop}
-        onShare={noop}
-        onProfile={noop}
-        avatarUrl="/avatar.png"
-        emojis={["😀", "😃", "😄"]}
-      />
+      <RadialMenu center={{ x: 0, y: 0 }} onClose={noop} items={items} />
     );
 
     const menu = getByRole("menu");
 
-    fireEvent.keyDown(menu, { key: "ArrowRight" }); // focus React
     fireEvent.keyDown(menu, { key: "Enter" }); // open react submenu
 
     await waitFor(() =>


### PR DESCRIPTION
## Summary
- refactor RadialMenu to accept config-driven nested submenus
- wire PortalOrb and AssistantOrb to provide compose submenu actions
- update tests for new radial menu API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ece9f067c832198662310ca2e40c9