### PR TITLE
chore: remove world state type from shared types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -51,14 +51,6 @@ export type RemixSpec = {
   params?: Record<string, unknown>;
 };
 
-export type WorldState = {
-  theme: "dark" | "light";
-  orbCount: number;
-  gridOpacity: number;
-  fogLevel: number;
-  orbColor: string;
-};
-
 declare global {
   namespace JSX {
     interface IntrinsicElements {


### PR DESCRIPTION
## Summary
- remove `WorldState` type from `src/types.ts`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed0d626a88321918ac3cab89846ed