### PR TITLE
Store AvatarPortal timeout and clear on cleanup

### DIFF
--- a/src/components/AvatarPortal.tsx
+++ b/src/components/AvatarPortal.tsx
@@ -5,7 +5,18 @@ import "./AvatarPortal.css";
 
 export default function AvatarPortal(){
   const [on, setOn] = useState(false);
-  useEffect(() => bus.on("avatar-portal:open", () => { setOn(true); setTimeout(()=>setOn(false), 900); }), []);
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const off = bus.on("avatar-portal:open", () => {
+      setOn(true);
+      timeoutId = setTimeout(() => setOn(false), 900);
+    });
+
+    return () => {
+      off();
+      clearTimeout(timeoutId);
+    };
+  }, []);
   return on ? (
     <div className="avatar-portal">
       <div className="ap-splash" />


### PR DESCRIPTION
## Summary
- Capture setTimeout handle in AvatarPortal
- Clear timeout and unsubscribe from bus on cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed0e0a94083219414dec6696bc025