### PR TITLE
feat: center radial menu control

### DIFF
--- a/src/components/RadialMenu.test.tsx
+++ b/src/components/RadialMenu.test.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import RadialMenu from "./RadialMenu";
 
 describe("RadialMenu keyboard navigation", () => {
   const noop = () => {};
 
   it("cycles through dynamic emoji counts", async () => {
-    const { getByRole } = render(
+    const { getByRole, getAllByRole } = render(
       <RadialMenu
         center={{ x: 0, y: 0 }}
         onClose={noop}
@@ -27,32 +27,80 @@ describe("RadialMenu keyboard navigation", () => {
     fireEvent.keyDown(menu, { key: "ArrowRight" }); // focus React
     fireEvent.keyDown(menu, { key: "Enter" }); // open react submenu
 
+    const submenu = getAllByRole("menu").find((el) =>
+      el.querySelector("#assistant-menu-item-emoji-0")
+    )!;
+
     await waitFor(() =>
-      expect(menu.getAttribute("aria-activedescendant")).toBe(
+      expect(submenu.getAttribute("aria-activedescendant")).toBe(
         "assistant-menu-item-emoji-0"
       )
     );
 
-    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(submenu, { key: "ArrowRight" });
     await waitFor(() =>
-      expect(menu.getAttribute("aria-activedescendant")).toBe(
+      expect(submenu.getAttribute("aria-activedescendant")).toBe(
         "assistant-menu-item-emoji-1"
       )
     );
 
-    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(submenu, { key: "ArrowRight" });
     await waitFor(() =>
-      expect(menu.getAttribute("aria-activedescendant")).toBe(
+      expect(submenu.getAttribute("aria-activedescendant")).toBe(
         "assistant-menu-item-emoji-2"
       )
     );
 
-    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(submenu, { key: "ArrowRight" });
     await waitFor(() =>
-      expect(menu.getAttribute("aria-activedescendant")).toBe(
+      expect(submenu.getAttribute("aria-activedescendant")).toBe(
+        "assistant-menu-item-back"
+      )
+    );
+
+    fireEvent.keyDown(submenu, { key: "ArrowRight" });
+    await waitFor(() =>
+      expect(submenu.getAttribute("aria-activedescendant")).toBe(
         "assistant-menu-item-emoji-0"
       )
     );
+  });
+
+  it("allows navigating to the center control", async () => {
+    const onClose = vi.fn();
+    const { getAllByRole } = render(
+      <RadialMenu
+        center={{ x: 0, y: 0 }}
+        onClose={onClose}
+        onChat={noop}
+        onReact={noop}
+        onComment={noop}
+        onRemix={noop}
+        onShare={noop}
+        onProfile={noop}
+        avatarUrl="/avatar.png"
+        emojis={[]}
+      />
+    );
+
+    const menus = getAllByRole("menu");
+    const menu = menus[menus.length - 1];
+
+    // cycle through the four root items to focus the close control
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+    fireEvent.keyDown(menu, { key: "ArrowRight" });
+
+    await waitFor(() =>
+      expect(menu.getAttribute("aria-activedescendant")).toBe(
+        "assistant-menu-item-close"
+      )
+    );
+
+    fireEvent.keyDown(menu, { key: "Enter" });
+
+    expect(onClose).toHaveBeenCalled();
   });
 });
 

--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -106,20 +106,30 @@ export default function RadialMenu({
       : createItems;
 
   function handleKeyDown(e: React.KeyboardEvent) {
+    const totalItems = currentItems.length + 1; // include center control
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       e.preventDefault();
-      setIndex((index + 1) % currentItems.length);
+      setIndex((index + 1) % totalItems);
     } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
       e.preventDefault();
-      setIndex((index - 1 + currentItems.length) % currentItems.length);
+      setIndex((index - 1 + totalItems) % totalItems);
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      const item = currentItems[index];
-      if ((item as any).next) {
-        setStep((item as any).next);
-        setIndex(0);
+      if (index === currentItems.length) {
+        if (step === "root") {
+          onClose();
+        } else {
+          setStep("root");
+          setIndex(0);
+        }
       } else {
-        (item as any).action();
+        const item = currentItems[index];
+        if ((item as any).next) {
+          setStep((item as any).next);
+          setIndex(0);
+        } else {
+          (item as any).action();
+        }
       }
     } else if (e.key === "Escape") {
       e.preventDefault();
@@ -189,7 +199,12 @@ export default function RadialMenu({
     );
   }
 
-  const activeId = currentItems[index]?.id || "";
+  const activeId =
+    index === currentItems.length
+      ? step === "root"
+        ? "close"
+        : "back"
+      : currentItems[index]?.id || "";
 
   return (
     <div
@@ -213,12 +228,27 @@ export default function RadialMenu({
           id={step === "root" ? "assistant-menu-item-close" : "assistant-menu-item-back"}
           role="menuitem"
           tabIndex={-1}
-          aria-label={step === "root" ? "Close" : "Back"}
+          aria-label={step === "root" ? "Close menu" : "Go back"}
           className="rbtn"
           style={{ left: -20, top: -20 }}
-          initial={reduceMotion ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={reduceMotion ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0 }}
+          initial={
+            reduceMotion
+              ? { opacity: 1, x: 0, y: 0, scale: 1 }
+              : { opacity: 0, x: 0, y: 0, scale: 0 }
+          }
+          animate={{
+            opacity: 1,
+            x: 0,
+            y: 0,
+            scale: 1,
+            boxShadow:
+              index === currentItems.length ? "0 0 0 2px #ff74de" : "none",
+          }}
+          exit={
+            reduceMotion
+              ? { opacity: 1, x: 0, y: 0, scale: 1 }
+              : { opacity: 0, x: 0, y: 0, scale: 0 }
+          }
           transition={{
             duration: reduceMotion ? 0 : 0.25,
             ease: [0.4, 0, 0.2, 1],


### PR DESCRIPTION
## Summary
- add accessible close/back control to radial menu center
- include central control in keyboard navigation and animations
- test navigation across menu items including center control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed09847d0832198085c303d65f34f