### PR TITLE
fix: guard topbar height calc

### DIFF
--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -17,7 +17,8 @@ export default function Topbar() {
   }, [theme]);
 
   useLayoutEffect(() => {
-    const el = ref.current!;
+    if (!ref.current) return;
+    const el = ref.current;
     const setH = () => {
       document.documentElement.style.setProperty("--topbar-h", `${el.offsetHeight}px`);
     };


### PR DESCRIPTION
## Summary
- guard topbar height calculation when its element ref is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed0def6a083218ca8240d00e2ea23