### PR TITLE
Clear PortalOverlay timeout on unmount

### DIFF
--- a/src/components/PortalOverlay.tsx
+++ b/src/components/PortalOverlay.tsx
@@ -3,9 +3,9 @@ import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 
 export default function PortalOverlay(){
-  const ref = useRef<HTMLDivElement|null>(null);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const timer = useRef<number | null>(null);
   const [on, setOn] = useState(false);
-  let timer: number | null = null;
 
   useEffect(() => {
     const off = bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
@@ -14,10 +14,11 @@ export default function PortalOverlay(){
       el.style.setProperty("--px", `${x}px`);
       el.style.setProperty("--py", `${y}px`);
       setOn(true);
-      timer = window.setTimeout(() => setOn(false), 700);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = window.setTimeout(() => setOn(false), 700);
     });
     return () => {
-      if (timer) clearTimeout(timer);
+      if (timer.current) clearTimeout(timer.current);
       off();
     };
   }, []);


### PR DESCRIPTION
## Summary
- prevent PortalOverlay timeout from running after unmount

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed0e33db88321b95b47311a7dda79