### PR TITLE
Add aria-hidden to profile avatar in radial menu

### DIFF
--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -52,6 +52,7 @@ export default function RadialMenu({
           <img
             src={avatarUrl}
             alt=""
+            aria-hidden="true"
             style={{ width: "100%", height: "100%", objectFit: "cover" }}
           />
         ),


### PR DESCRIPTION
## Summary
- hide profile avatar image from screen readers in radial menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed0e530ac8321a9144645ae02a398