### PR TITLE
Handle localStorage access errors

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,13 @@
 // src/lib/api.ts
 export async function assistantReply(prompt: string): Promise<{ ok: boolean; text?: string; error?: string }> {
-  const apiKey = typeof window !== "undefined"
-    ? localStorage.getItem("sn2177.apiKey") || ""
-    : "";
+  let apiKey = "";
+  if (typeof window !== "undefined") {
+    try {
+      apiKey = localStorage.getItem("sn2177.apiKey") || "";
+    } catch {
+      apiKey = "";
+    }
+  }
   try {
     const r = await fetch("/api/assistant-reply", {
       method: "POST",


### PR DESCRIPTION
## Summary
- gracefully handle localStorage access when retrieving the API key in `assistantReply`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed256525483218e90e4f9e1a511aa