### PR TITLE
refactor: tighten sharePost arg types

### DIFF
--- a/src/hooks/useShare.ts
+++ b/src/hooks/useShare.ts
@@ -13,8 +13,11 @@ import {
  * Returns true if sharing/copy succeeded, false otherwise.
  */
 export function sharePost(url: string, title?: string): Promise<boolean>;
-export function sharePost(arg: Post | ShareOptions | string): Promise<boolean>;
-export async function sharePost(arg: any, title?: string): Promise<boolean> {
+export function sharePost(arg: Post | ShareOptions | string, title?: never): Promise<boolean>;
+export async function sharePost(
+  arg: Post | ShareOptions | string,
+  title?: string,
+): Promise<boolean> {
   try {
     // Old signature: (url: string, title?: string)
     if (typeof arg === "string" && (title === undefined || typeof title === "string")) {


### PR DESCRIPTION
## Summary
- remove `any` from `sharePost` implementation and use `Post | ShareOptions | string`
- tighten overloads so second parameter is only allowed for the legacy string-based signature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed257bec4832199f7ad831f32af9f