### PR TITLE
feat: add alt text for post composer images

### DIFF
--- a/src/components/PostComposer.tsx
+++ b/src/components/PostComposer.tsx
@@ -164,7 +164,7 @@ export default function PostComposer() {
         <div className="composer__attachments">
           {images.map((src, i) => (
             <div className="att" key={`img-${i}`}>
-              <img src={src} alt="" />
+              <img src={src} alt={`attachment ${i + 1}`} />
               <button className="att__x" title="Remove" onClick={() => removeImage(i)}>
                 ×
               </button>


### PR DESCRIPTION
## Summary
- add alt text for attachments in PostComposer to improve accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed25a0e148321ba6b48e6d3482d4b