### PR TITLE
Use stable key for BackgroundVoid Float elements

### DIFF
--- a/src/three/BackgroundVoid.tsx
+++ b/src/three/BackgroundVoid.tsx
@@ -61,7 +61,12 @@ export default function BackgroundVoid() {
             metalness={0.55}
           />
           {positions.map((p, i) => (
-            <Float key={i} floatIntensity={0.6} rotationIntensity={0.25} speed={0.9 + (i % 4) * 0.15}>
+            <Float
+              key={p.join(",")}
+              floatIntensity={0.6}
+              rotationIntensity={0.25}
+              speed={0.9 + (i % 4) * 0.15}
+            >
               <Instance position={p} />
             </Float>
           ))}


### PR DESCRIPTION
## Summary
- derive stable keys for Float instances from their position arrays instead of using array indexes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed25c88588321845c9f943888322b