### PR TITLE
feat: handle bus listener errors

### DIFF
--- a/src/lib/bus.test.ts
+++ b/src/lib/bus.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { on, emit } from "./bus";
+
+describe("bus", () => {
+  it("handles listener errors via callback", () => {
+    const off1 = on("evt", () => { throw new Error("boom"); });
+    let called = false;
+    const off2 = on("evt", () => { called = true; });
+
+    const errors: unknown[] = [];
+    emit("evt", undefined, (err) => errors.push(err));
+
+    expect(errors).toHaveLength(1);
+    expect(called).toBe(true);
+
+    off1();
+    off2();
+  });
+
+  it("rethrows listener errors when no callback provided", () => {
+    const off = on("evt", () => { throw new Error("boom"); });
+    expect(() => emit("evt")).toThrow("boom");
+    off();
+  });
+});

--- a/src/lib/bus.ts
+++ b/src/lib/bus.ts
@@ -12,7 +12,20 @@ export function off(event: string, handler: Handler) {
   handlers?.delete(handler);
   if (handlers && handlers.size === 0) listeners.delete(event);
 }
-export function emit(event: string, payload?: any) {
-  listeners.get(event)?.forEach(fn => { try { fn(payload); } catch (e) { console.error(e); } });
+export function emit(
+  event: string,
+  payload?: any,
+  onError?: (err: unknown) => void,
+) {
+  const handlers = listeners.get(event);
+  if (!handlers) return;
+  for (const fn of handlers) {
+    try {
+      fn(payload);
+    } catch (e) {
+      if (onError) onError(e);
+      else throw e;
+    }
+  }
 }
 export default { on, off, emit };


### PR DESCRIPTION
## Summary
- handle listener errors via optional callback
- add tests for bus error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed262db8883218b55c9018806847a