### PR TITLE
Guard sidebar reset for non-browser environments

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -51,10 +51,18 @@ export default function Sidebar() {
   const [showKey, setShowKey] = useState<string | null>(null);
   const setKey = (k: keyof Keys, v: string) => setKeys({ ...keys, [k]: v });
   const clearAll = () => {
-    Object.keys(localStorage)
+    if (
+      typeof window === "undefined" ||
+      !window.localStorage ||
+      typeof window.location?.reload !== "function"
+    ) {
+      return;
+    }
+
+    Object.keys(window.localStorage)
       .filter(k => k.startsWith("sn."))
-      .forEach(k => localStorage.removeItem(k));
-    location.reload();
+      .forEach(k => window.localStorage.removeItem(k));
+    window.location.reload();
   };
 
   return (


### PR DESCRIPTION
## Summary
- safeguard `clearAll` in `Sidebar` for server-side rendering by verifying `window` availability before accessing `localStorage` and `location`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed26fa7108321b8133843ffea1334