### PR TITLE
feat: enhance radial menu styling

### DIFF
--- a/src/components/RadialMenu.css
+++ b/src/components/RadialMenu.css
@@ -5,16 +5,19 @@
   border-radius: 9999px;
   display: grid;
   place-items: center;
-  background: rgba(14, 16, 22, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: #fff;
+  background: var(--rm-bg);
+  border: 1px solid var(--rm-border);
+  color: var(--rm-ink);
   cursor: pointer;
-  backdrop-filter: blur(8px) saturate(140%);
+  backdrop-filter: blur(var(--rm-blur)) saturate(140%);
   transform-origin: center;
-  transition: background 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--rm-shadow);
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    opacity 0.2s ease;
 }
 
-.rbtn:hover {
-  background: rgba(14, 16, 22, 0.85);
-  box-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
+.rbtn:hover,
+.rbtn:focus-visible {
+  background: var(--rm-bg-hover);
+  box-shadow: var(--rm-shadow-hover);
 }

--- a/src/components/RadialMenu.tsx
+++ b/src/components/RadialMenu.tsx
@@ -197,7 +197,7 @@ export default function RadialMenu({
           x,
           y,
           scale: 1,
-          boxShadow: active ? "0 0 0 2px #ff74de" : "none",
+          boxShadow: active ? "0 0 0 2px var(--rm-ring)" : "none",
         }}
         exit={
           reduceMotion
@@ -208,7 +208,12 @@ export default function RadialMenu({
           duration: reduceMotion ? 0 : 0.25,
           ease: [0.4, 0, 0.2, 1],
         }}
-        whileHover={reduceMotion ? undefined : { scale: 1.1 }}
+        whileHover={
+          reduceMotion ? undefined : { scale: 1.06, opacity: 0.95 }
+        }
+        whileFocus={
+          reduceMotion ? undefined : { scale: 1.06, opacity: 0.95 }
+        }
         onClick={() => {
           if (item.next) {
             setStep(item.next);
@@ -266,7 +271,9 @@ export default function RadialMenu({
             y: 0,
             scale: 1,
             boxShadow:
-              index === currentItems.length ? "0 0 0 2px #ff74de" : "none",
+              index === currentItems.length
+                ? "0 0 0 2px var(--rm-ring)"
+                : "none",
           }}
           exit={
             reduceMotion
@@ -277,7 +284,12 @@ export default function RadialMenu({
             duration: reduceMotion ? 0 : 0.25,
             ease: [0.4, 0, 0.2, 1],
           }}
-          whileHover={reduceMotion ? undefined : { scale: 1.1 }}
+          whileHover={
+            reduceMotion ? undefined : { scale: 1.06, opacity: 0.95 }
+          }
+          whileFocus={
+            reduceMotion ? undefined : { scale: 1.06, opacity: 0.95 }
+          }
           onClick={() => {
             if (step === "root") {
               onClose();

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,14 @@
   --chip-ink: #fff;
   --radius: 14px;
   --shadow: 0 10px 30px rgba(11,15,26,.08), 0 1px 0 rgba(255,255,255,.7) inset;
+  --rm-bg: linear-gradient(145deg, rgba(14,16,22,.85), rgba(14,16,22,.65));
+  --rm-bg-hover: linear-gradient(145deg, rgba(14,16,22,.9), rgba(14,16,22,.7));
+  --rm-border: rgba(255,255,255,.2);
+  --rm-shadow: 0 8px 20px rgba(11,15,26,.25);
+  --rm-shadow-hover: 0 12px 28px rgba(11,15,26,.35);
+  --rm-blur: 14px;
+  --rm-ink: #fff;
+  --rm-ring: #ff74de;
 }
 
 *{ box-sizing:border-box; }


### PR DESCRIPTION
## Summary
- add theme tokens for radial menu buttons
- apply gradient, blur, and shadow improvements to rbtn
- add subtle scale/opacity feedback on hover/focus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed2e807ac8321882fa0bbf9a54b27