### PR TITLE
Align PortalOrb gestures with AssistantOrb

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import type { AssistantMessage, Post } from "../types";
 import RadialMenu from "./RadialMenu";
+import { HOLD_MS } from "./orbConstants";
 import { motion, useReducedMotion } from "framer-motion";
 
 /**
@@ -27,7 +28,6 @@ type SpeechRecognitionLike = {
 
 const ORB_SIZE = 76;
 const ORB_MARGIN = 12;
-const HOLD_MS = 280;
 const DRAG_THRESHOLD = 5;
 const PANEL_WIDTH = 360;
 const STORAGE_KEY = "assistantOrbPos.v6";

--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -1,16 +1,14 @@
 import React, { useEffect, useRef, useState } from "react";
 import usePointer from "../hooks/usePointer";
 import bus from "../lib/bus";
+import RadialMenu from "./RadialMenu";
+import { HOLD_MS, MOVE_TOLERANCE, SNAP_PADDING } from "./orbConstants";
 
 type Props = {
   onAnalyzeImage: (imgUrl: string) => void;
 };
 
 type Mode = "idle" | "menu" | "analyze";
-
-const HOLD_MS = 600;
-const SNAP_PADDING = 12;
-const MOVE_TOLERANCE = 8;
 
 export default function PortalOrb({ onAnalyzeImage }: Props) {
   const orbRef = useRef<HTMLDivElement>(null);
@@ -19,9 +17,6 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   const originRef = useRef({ x: 0, y: 0 });
   const [mode, setMode] = useState<Mode>("idle");
   const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const [menuIndex, setMenuIndex] = useState(0);
   const [pos, setPos] = useState<{ x: number; y: number }>(() => {
     if (typeof window !== "undefined") {
       const saved = localStorage.getItem("orb-pos");
@@ -30,7 +25,6 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
     return { x: 16, y: 16 };
   });
   const [dragging, setDragging] = useState(false);
-  const lastTap = useRef<number>(0);
   const analyzeOverlay = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -54,31 +48,13 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
 
   function handlePointerDown(e: React.PointerEvent) {
     (e.currentTarget as Element).setPointerCapture(e.pointerId);
-
-    // double-tap to snap top-left + vortex
-    const now = Date.now();
-    if (now - lastTap.current < 300) {
-      setMenuOpen(false);
-      setMode("idle");
-      setPos({ x: 12, y: 12 });
-      orbRef.current?.classList.add("vortex");
-      window.setTimeout(
-        () => orbRef.current?.classList.remove("vortex"),
-        900
-      );
-      return;
-    }
-    lastTap.current = now;
-
     setDragging(true);
     startRef.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
     originRef.current = { x: e.clientX, y: e.clientY };
 
-    // long-press => open radial menu
+    // long-press => analyze mode
     holdRef.current = window.setTimeout(() => {
-      setMenuOpen(true);
-      setMode("menu");
-      orbRef.current?.classList.add("grow");
+      startAnalyze();
     }, HOLD_MS);
   }
 
@@ -133,6 +109,15 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   }
 
   function handlePointerUp(ev: PointerEvent) {
+    const isTap =
+      Math.hypot(ev.clientX - originRef.current.x, ev.clientY - originRef.current.y) <=
+      MOVE_TOLERANCE;
+    if (mode !== "analyze" && isTap) {
+      const next = !menuOpen;
+      setMenuOpen(next);
+      setMode(next ? "menu" : "idle");
+      orbRef.current?.classList.toggle("grow", next);
+    }
     finishInteraction(ev);
   }
 
@@ -166,31 +151,14 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
     analyzeOverlay.current = null;
   }
 
-  const actions: { icon: React.ReactNode; label: string; callback: () => void }[] = [
+  const actions: {
+    id: string;
+    icon: React.ReactNode;
+    label: string;
+    action: () => void;
+  }[] = [
     {
-      icon: (
-        <svg viewBox="0 0 24 24" className="ico">
-          <path
-            d="M15.5 15.5L21 21"
-            stroke="currentColor"
-            strokeWidth="2"
-            fill="none"
-            strokeLinecap="square"
-          />
-          <circle
-            cx="10"
-            cy="10"
-            r="6"
-            stroke="currentColor"
-            strokeWidth="2"
-            fill="none"
-          />
-        </svg>
-      ),
-      label: "Analyze",
-      callback: startAnalyze,
-    },
-    {
+      id: "compose",
       icon: (
         <svg className="ico" viewBox="0 0 24 24">
           <path
@@ -202,7 +170,7 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
         </svg>
       ),
       label: "Compose",
-      callback: () => {
+      action: () => {
         setMode("idle");
         setMenuOpen(false);
         orbRef.current?.classList.remove("grow");
@@ -210,6 +178,28 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
       },
     },
     {
+      id: "recenter",
+      icon: (
+        <svg className="ico" viewBox="0 0 24 24">
+          <path
+            d="M12 5v14M5 12h14"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+        </svg>
+      ),
+      label: "Recenter",
+      action: () => {
+        setMode("idle");
+        setMenuOpen(false);
+        setPos({ x: 12, y: 12 });
+        orbRef.current?.classList.remove("grow");
+        orbRef.current?.classList.add("vortex");
+        window.setTimeout(() => orbRef.current?.classList.remove("vortex"), 900);
+      },
+    },
+    {
+      id: "close",
       icon: (
         <svg className="ico" viewBox="0 0 24 24">
           <path
@@ -220,7 +210,7 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
         </svg>
       ),
       label: "Close",
-      callback: () => {
+      action: () => {
         setMode("idle");
         setMenuOpen(false);
         orbRef.current?.classList.remove("grow");
@@ -242,38 +232,7 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
     }
   }
 
-  function handleMenuKey(e: React.KeyboardEvent) {
-    const items = itemRefs.current.filter(Boolean) as HTMLButtonElement[];
-    if (!items.length) return;
-    if (e.key === "ArrowRight" || e.key === "ArrowDown" || (e.key === "Tab" && !e.shiftKey)) {
-      e.preventDefault();
-      const next = (menuIndex + 1) % items.length;
-      setMenuIndex(next);
-      items[next]?.focus();
-    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp" || (e.key === "Tab" && e.shiftKey)) {
-      e.preventDefault();
-      const next = (menuIndex - 1 + items.length) % items.length;
-      setMenuIndex(next);
-      items[next]?.focus();
-    } else if (e.key === "Escape") {
-      setMenuOpen(false);
-      setMode("idle");
-      orbRef.current?.focus();
-    } else if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      items[menuIndex]?.click();
-    }
-  }
-
-  useEffect(() => {
-    if (menuOpen) {
-      setMenuIndex(0);
-      const first = itemRefs.current[0];
-      first?.focus();
-    } else {
-      itemRefs.current = [];
-    }
-  }, [menuOpen]);
+  // radial menu handled by shared component
 
   usePointer(dragging, {
     onMove: handlePointerMove,
@@ -301,47 +260,15 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
         <div className="orb-core" />
         {/* radial menu */}
         {menuOpen && (
-          <div
-            className="radial-menu"
-            role="menu"
-            aria-label="Portal actions"
-            ref={menuRef}
-            onKeyDown={handleMenuKey}
-            aria-activedescendant={`portal-orb-item-${menuIndex}`}
-          >
-            {actions.map((action, i) => {
-              const angle = (360 / actions.length) * i - 90;
-              const rad = (angle * Math.PI) / 180;
-              const iconX = 94 * Math.cos(rad);
-              const iconY = 94 * Math.sin(rad);
-              const labelX = 140 * Math.cos(rad);
-              const labelY = 140 * Math.sin(rad);
-              return (
-                <React.Fragment key={action.label}>
-                  <button
-                    className="rm-item"
-                    onClick={action.callback}
-                    title={action.label}
-                    role="menuitem"
-                    ref={(el) => (itemRefs.current[i] = el)}
-                    tabIndex={menuIndex === i ? 0 : -1}
-                    id={`portal-orb-item-${i}`}
-                    style={{ transform: `translate(${iconX}px, ${iconY}px)` }}
-                  >
-                    {action.icon}
-                  </button>
-                  <span
-                    className="rm-label"
-                    style={{
-                      transform: `translate(${labelX}px, ${labelY}px) translate(-50%, -50%)`,
-                    }}
-                  >
-                    {action.label}
-                  </span>
-                </React.Fragment>
-              );
-            })}
-          </div>
+          <RadialMenu
+            center={{ x: pos.x + 32, y: pos.y + 32 }}
+            items={actions}
+            onClose={() => {
+              setMenuOpen(false);
+              setMode("idle");
+              orbRef.current?.classList.remove("grow");
+            }}
+          />
         )}
       </div>
 
@@ -381,20 +308,6 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
         }
         @keyframes spin{ to{ filter:hue-rotate(90deg) saturate(1.3) } }
 
-        .radial-menu{
-          position:absolute;inset:-30px;display:grid;place-items:center;pointer-events:none;
-        }
-        .rm-item{
-          position:absolute;pointer-events:auto;
-          display:grid;place-items:center;gap:6px;padding:6px 8px;background:rgba(16,18,24,.9);
-          border:1px solid var(--stroke-2);color:#fff;
-        }
-        .rm-item .ico{width:18px;height:18px}
-        .rm-label{
-          position:absolute;pointer-events:none;
-          padding:2px 4px;background:rgba(16,18,24,.9);
-          border:1px solid var(--stroke-2);color:#fff;font-size:12px;
-        }
         .analyzing .orb-core{ box-shadow:0 0 0 1px rgba(255,255,255,.08) inset, 0 10px 70px rgba(10,132,255,.7) }
       `}</style>
     </>

--- a/src/components/RadialMenu.css
+++ b/src/components/RadialMenu.css
@@ -18,3 +18,14 @@
   background: rgba(14, 16, 22, 0.85);
   box-shadow: 0 0 8px rgba(255, 255, 255, 0.2);
 }
+
+.rm-label {
+  position: absolute;
+  pointer-events: none;
+  padding: 2px 4px;
+  background: rgba(16, 18, 24, 0.9);
+  border: 1px solid var(--stroke-2);
+  color: #fff;
+  font-size: 12px;
+  transform: translate(-50%, -50%);
+}

--- a/src/components/orbConstants.ts
+++ b/src/components/orbConstants.ts
@@ -1,0 +1,3 @@
+export const HOLD_MS = 280;
+export const MOVE_TOLERANCE = 8;
+export const SNAP_PADDING = 12;


### PR DESCRIPTION
## Summary
- Make PortalOrb radial menu open on tap and move analyze to long-press
- Add recenter option and use shared RadialMenu component for consistent UX
- Introduce shared orb gesture constants used by both Portal and Assistant orbs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed2f0689083218945b89073410bbb