### PR TITLE
feat: type assistant-reply handler

### DIFF
--- a/api/assistant-reply.ts
+++ b/api/assistant-reply.ts
@@ -1,16 +1,30 @@
 // /api/assistant-reply.ts
-export default async function handler(req: any, res: any) {
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(
+  req: VercelRequest,
+  res: VercelResponse,
+) {
   if (req.method !== "POST") {
     return res.status(405).json({ ok: false, error: "Method not allowed" });
   }
 
   // Prefer the server env var; fall back to client-supplied key for local/dev.
-  const body = (req.body ?? {}) as any;
+  const body = (req.body ?? {}) as {
+    apiKey?: string;
+    prompt?: string;
+    q?: string;
+  };
   const apiKey = process.env.OPENAI_API_KEY || body.apiKey || "";
   if (!apiKey) return res.status(500).json({ ok: false, error: "Missing OPENAI_API_KEY" });
 
   // Accept either {prompt} or {q}
-  const raw = typeof body.prompt === "string" ? body.prompt : (typeof body.q === "string" ? body.q : "");
+  const raw =
+    typeof body.prompt === "string"
+      ? body.prompt
+      : typeof body.q === "string"
+        ? body.q
+        : "";
   const prompt = (raw || "").trim();
   if (!prompt) return res.status(400).json({ ok: false, error: "Missing prompt" });
 


### PR DESCRIPTION
## Summary
- type the assistant reply API handler with Vercel request/response
- structure request body typing for prompt and api key handling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ed3a457c08321aea0c21eb32ec2e9