### PR TITLE
Simplify image onload swap

### DIFF
--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -82,25 +82,11 @@ export default function InfiniteFeed({
               loading="lazy"
               decoding="async"
               onLoad={(e) => {
-                // swap to full-res when in view using data-src if the browser kept the thumb
                 const el = e.currentTarget;
                 // upgrade if we were still on thumb
                 if (el.dataset.src && el.src.indexOf("picsum.photos/id") > -1 && el.src.includes("/200/")) {
-                  const swap = () => {
-                    el.src = el.dataset.src as string;
-                    delete el.dataset.src;
-                  };
-                  if ("IntersectionObserver" in window) {
-                    const io = new IntersectionObserver((entries, obs) => {
-                      if (entries[0].isIntersecting) {
-                        swap();
-                        obs.disconnect();
-                      }
-                    });
-                    io.observe(el);
-                  } else {
-                    swap();
-                  }
+                  el.src = el.dataset.src as string;
+                  delete el.dataset.src;
                 }
               }}
             />


### PR DESCRIPTION
## Summary
- Simplify `InfiniteFeed` image onLoad handler to swap in full-res source immediately
- Remove obsolete IntersectionObserver comment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed28b89bc832198ba54286d968e54