### PR TITLE
Handle missing canvas context in ThirteenthFloorWorld

### DIFF
--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -82,12 +82,18 @@ function Portal() {
   );
 }
 
-function makeLabelTexture(name: string, color = "#2eff7a") {
+function makeLabelTexture(
+  name: string,
+  color = "#2eff7a"
+): THREE.Texture | undefined {
   const canvas = document.createElement("canvas");
   const dpr = Math.min(2, window.devicePixelRatio || 1);
   canvas.width = 256 * dpr;
   canvas.height = 128 * dpr;
-  const g = canvas.getContext("2d")!;
+  const g = canvas.getContext("2d");
+  if (!g) {
+    return;
+  }
   g.scale(dpr, dpr);
 
   g.fillStyle = "rgba(10, 20, 10, 0.1)";


### PR DESCRIPTION
## Summary
- guard canvas 2D context acquisition and return early when unavailable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed29052648321a0bf1633ddd91a95