### PR TITLE
style: enhance assistant orb visuals

### DIFF
--- a/src/components/AssistantOrb.css
+++ b/src/components/AssistantOrb.css
@@ -1,5 +1,102 @@
-.assistant-orb{position:fixed;width:76px;height:76px;border-radius:50%;border:none;padding:0;background:transparent;touch-action:none;}
-.assistant-orb__core{position:absolute;inset:8px;border-radius:50%;background:#4b6;}
-.assistant-orb__ring{position:absolute;inset:0;border-radius:50%;border:2px solid #4b6;animation:ping 2s infinite;}
-.assistant-orb__toast{position:absolute;top:-30px;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:2px 6px;border-radius:4px;font-size:12px;}
-@keyframes ping{from{transform:scale(.9);opacity:.6;}to{transform:scale(1.4);opacity:0;}}
+:root {
+  /* Assistant orb theme tokens */
+  --orb-size: 76px;
+  --orb-color: var(--pink, #ff74de);
+  --orb-blur: 14px;
+}
+
+.assistant-orb {
+  position: fixed;
+  width: var(--orb-size);
+  height: var(--orb-size);
+  border-radius: 50%;
+  border: 1px solid var(--stroke-2);
+  display: grid;
+  place-items: center;
+  cursor: grab;
+  overflow: hidden;
+  background: radial-gradient(
+    120% 120% at 30% 30%,
+    #fff,
+    color-mix(in srgb, var(--orb-color) 45%, transparent) 60%,
+    var(--orb-color)
+  );
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.35),
+    0 0 0 8px color-mix(in srgb, var(--orb-color) 25%, transparent);
+  backdrop-filter: blur(var(--orb-blur)) saturate(140%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  touch-action: none;
+}
+
+.assistant-orb:hover {
+  transform: scale(1.03);
+  filter: saturate(115%);
+}
+
+.assistant-orb:active {
+  transform: scale(0.97);
+}
+
+.assistant-orb__core {
+  width: calc(var(--orb-size) - 20px);
+  height: calc(var(--orb-size) - 20px);
+  border-radius: 50%;
+  background: radial-gradient(
+    60% 60% at 40% 35%,
+    rgba(255, 255, 255, 0.95),
+    rgba(255, 255, 255, 0.3) 65%,
+    transparent 70%
+  );
+}
+
+.assistant-orb__ring {
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  box-shadow: inset 0 0 24px rgba(255, 255, 255, 0.55);
+}
+
+.assistant-orb.mic .assistant-orb__ring {
+  animation: orb-ping 1.4s ease-out infinite;
+}
+
+@keyframes orb-ping {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--orb-color) 30%, transparent 70%);
+  }
+  100% {
+    box-shadow: 0 0 0 28px rgba(0, 0, 0, 0);
+  }
+}
+
+.assistant-orb__toast {
+  position: absolute;
+  white-space: nowrap;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.assistant-orb__toast.right {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.assistant-orb__toast.left {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.assistant-orb__toast.interim {
+  bottom: calc(100% + 4px);
+  top: auto;
+  transform: none;
+}
+

--- a/src/components/RadialMenu.css
+++ b/src/components/RadialMenu.css
@@ -1,3 +1,15 @@
+:root {
+  --orb-color: var(--pink, #ff74de);
+  --rm-bg: color-mix(in srgb, var(--orb-color) 8%, var(--glass, rgba(14, 16, 22, 0.36)));
+  --rm-bg-hover: color-mix(in srgb, var(--orb-color) 14%, var(--glass, rgba(14, 16, 22, 0.36)));
+  --rm-border: var(--stroke-2);
+  --rm-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  --rm-shadow-hover: 0 12px 28px rgba(0, 0, 0, 0.35);
+  --rm-blur: var(--orb-blur, 14px);
+  --rm-ink: var(--ink);
+  --rm-ring: var(--orb-color);
+}
+
 .rbtn {
   position: absolute;
   width: 40px;
@@ -22,13 +34,18 @@
   box-shadow: var(--rm-shadow-hover);
 }
 
+.rbtn:active {
+  transform: scale(0.94);
+}
+
 .rm-label {
   position: absolute;
   pointer-events: none;
   padding: 2px 4px;
-  background: rgba(16, 18, 24, 0.9);
+  background: var(--glass-strong, rgba(16, 18, 24, 0.9));
   border: 1px solid var(--stroke-2);
-  color: #fff;
+  color: var(--ink);
   font-size: 12px;
+  backdrop-filter: blur(var(--rm-blur)) saturate(140%);
   transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
## Summary
- revamp assistant orb with translucent gradient background, variables and smooth states
- align radial menu styling to share orb color tokens and blur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f6a73cc34832188d8170ee303f8ab