### PR TITLE
feat: theme-aware orb tokens

### DIFF
--- a/src/components/AvatarPortal.css
+++ b/src/components/AvatarPortal.css
@@ -5,7 +5,7 @@
 }
 .ap-splash{
   position:absolute; top:8px; left:8px; width:36px; height:36px; border-radius:999px;
-  background: radial-gradient(120% 120% at 30% 30%, #fff, #ffc6f3 60%, var(--pink));
+  background: radial-gradient(120% 120% at 30% 30%, #fff, var(--orb-surface) 60%, var(--orb-color));
   filter: blur(0px);
   animation: apSplash .9s cubic-bezier(.2,.9,.1,1) forwards;
   transform-origin: top left;

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,6 +26,12 @@ button, input, textarea, select { font: inherit; color: inherit; }
   /* Theme accents */
   --pink: #ff74de;   /* Assistant orb theme */
   --blue: #4f7afe;   /* Brand/top-left orb theme */
+  --orb-color: var(--pink);
+  --orb-surface: color-mix(in srgb, #fff 65%, var(--orb-color) 35%);
+  --orb-shadow: 0 12px 30px rgba(0,0,0,.35);
+  --orb-ring: color-mix(in srgb, var(--orb-color) 25%, transparent 75%);
+  --orb-ring-strong: color-mix(in srgb, var(--orb-color) 35%, transparent 65%);
+  --orb-ping: color-mix(in srgb, var(--orb-color) 30%, transparent 70%);
 }
 
 :root[data-theme="light"] {
@@ -38,6 +44,12 @@ button, input, textarea, select { font: inherit; color: inherit; }
   --glass: color-mix(in srgb, rgba(255,255,255,0.8) 65%, var(--glass-base) 35%);
   --glass-strong: color-mix(in srgb, rgba(255,255,255,0.9) 75%, var(--glass-base) 25%);
   --shadow: 0 4px 12px rgba(0,0,0,0.08);
+  --orb-color: var(--pink);
+  --orb-surface: color-mix(in srgb, #fff 75%, var(--orb-color) 25%);
+  --orb-shadow: 0 8px 24px rgba(0,0,0,.18);
+  --orb-ring: color-mix(in srgb, var(--orb-color) 35%, transparent 65%);
+  --orb-ring-strong: color-mix(in srgb, var(--orb-color) 45%, transparent 55%);
+  --orb-ping: color-mix(in srgb, var(--orb-color) 40%, transparent 60%);
 }
 
 /* =========================
@@ -155,13 +167,13 @@ button, input, textarea, select { font: inherit; color: inherit; }
   contain: layout paint;
   will-change: transform;
   transition: transform .16s ease, box-shadow .2s ease, filter .2s ease;
-  background: radial-gradient(120% 120% at 30% 30%, #fff, #ffd7f5 60%, var(--pink));
-  box-shadow: 0 12px 30px rgba(0,0,0,.35), 0 0 0 8px color-mix(in srgb, var(--pink) 25%, transparent 75%);
+  background: radial-gradient(120% 120% at 30% 30%, #fff, var(--orb-surface) 60%, var(--orb-color));
+  box-shadow: var(--orb-shadow), 0 0 0 8px var(--orb-ring);
 }
 .assistant-orb:hover { filter: saturate(115%); }
 .assistant-orb.flying { pointer-events: none; filter: saturate(150%); transition: none; }
 .assistant-orb.mic {
-  box-shadow: 0 12px 30px rgba(0,0,0,.35), 0 0 0 10px color-mix(in srgb, var(--pink) 35%, transparent 65%);
+  box-shadow: var(--orb-shadow), 0 0 0 10px var(--orb-ring-strong);
 }
 .assistant-orb__core{
   width: 56px; height: 56px; border-radius: 50%;
@@ -173,7 +185,7 @@ button, input, textarea, select { font: inherit; color: inherit; }
 }
 .assistant-orb.mic .assistant-orb__ring{ animation: orb-ping 1.4s ease-out infinite; }
 @keyframes orb-ping{
-  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--pink) 30%, transparent 70%); }
+  0%   { box-shadow: 0 0 0 0 var(--orb-ping); }
   100% { box-shadow: 0 0 0 28px rgba(0,0,0,0); }
 }
 .assistant-orb__toast{
@@ -231,8 +243,8 @@ button, input, textarea, select { font: inherit; color: inherit; }
 .ap-dot{
   width: 22px; height: 22px; border-radius: 999px;
   border: 1px solid rgba(255,255,255,.2);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--pink) 25%, transparent 75%);
-  background: radial-gradient(120% 120% at 30% 30%, #fff, #ffc6f3 60%, var(--pink));
+  box-shadow: 0 0 0 4px var(--orb-ring);
+  background: radial-gradient(120% 120% at 30% 30%, #fff, var(--orb-surface) 60%, var(--orb-color));
 }
 .ap-title{ font-weight: 800; }
 .ap-sub{ font-size: 12px; opacity: .8; }
@@ -278,7 +290,7 @@ button, input, textarea, select { font: inherit; color: inherit; }
   height: 36px; padding: 0 10px; border-radius: 10px; cursor: pointer;
   background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.16); color: #fff;
 }
-.ap-mic.on{ box-shadow: inset 0 0 0 3px color-mix(in srgb, var(--pink) 30%, transparent 70%); }
+.ap-mic.on{ box-shadow: inset 0 0 0 3px var(--orb-ping); }
 
 /* =========================
    World UI (bottom glass bar)


### PR DESCRIPTION
## Summary
- add orb color, surface and shadow CSS variables for dark and light themes
- refactor assistant/portal orb styles to use new tokens
- ensure gradient and shadow values stay visible across themes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6be8e6588321aa382271d764c87b