### PR TITLE
feat: add orb and radial menu theme tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,14 +10,33 @@
   --chip-ink: #fff;
   --radius: 14px;
   --shadow: 0 10px 30px rgba(11,15,26,.08), 0 1px 0 rgba(255,255,255,.7) inset;
-  --rm-bg: linear-gradient(145deg, rgba(14,16,22,.85), rgba(14,16,22,.65));
-  --rm-bg-hover: linear-gradient(145deg, rgba(14,16,22,.9), rgba(14,16,22,.7));
-  --rm-border: rgba(255,255,255,.2);
-  --rm-shadow: 0 8px 20px rgba(11,15,26,.25);
-  --rm-shadow-hover: 0 12px 28px rgba(11,15,26,.35);
+  --orb-bg: radial-gradient(120% 120% at 30% 30%, #fff, #dbe4ff 60%, var(--brand));
+  --orb-border: rgba(0,0,0,.08);
+  --orb-shadow: 0 8px 20px rgba(11,15,26,.12);
+  --orb-shadow-hover: 0 12px 28px rgba(11,15,26,.2);
+  --rm-bg: linear-gradient(145deg, rgba(255,255,255,.95), rgba(255,255,255,.75));
+  --rm-bg-hover: linear-gradient(145deg, rgba(255,255,255,1), rgba(255,255,255,.85));
+  --rm-border: rgba(0,0,0,.1);
+  --rm-shadow: 0 8px 20px rgba(11,15,26,.12);
+  --rm-shadow-hover: 0 12px 28px rgba(11,15,26,.18);
   --rm-blur: 14px;
-  --rm-ink: #fff;
+  --rm-ink: var(--ink-0);
   --rm-ring: #ff74de;
+}
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --orb-bg: radial-gradient(120% 120% at 30% 30%, rgba(255,255,255,.18), rgba(255,255,255,0) 60%, rgba(10,132,255,.35));
+    --orb-border: rgba(255,255,255,.12);
+    --orb-shadow: 0 8px 24px rgba(0,0,0,.6);
+    --orb-shadow-hover: 0 12px 32px rgba(0,0,0,.7);
+    --rm-bg: linear-gradient(145deg, rgba(14,16,22,.85), rgba(14,16,22,.65));
+    --rm-bg-hover: linear-gradient(145deg, rgba(14,16,22,.9), rgba(14,16,22,.7));
+    --rm-border: rgba(255,255,255,.2);
+    --rm-shadow: 0 8px 20px rgba(0,0,0,.25);
+    --rm-shadow-hover: 0 12px 28px rgba(0,0,0,.35);
+    --rm-ink: #fff;
+  }
 }
 
 *{ box-sizing:border-box; }


### PR DESCRIPTION
## Summary
- add light theme tokens for orb and radial menu
- provide dark theme overrides using prefers-color-scheme

## Testing
- `npm test`
- `node contrast-check.js`

------
https://chatgpt.com/codex/tasks/task_e_689f6cd0178c8321bdd842b5a5167eb1