### PR TITLE
refactor: migrate rm tokens to orb tokens

### DIFF
--- a/src/components/RadialMenu.css
+++ b/src/components/RadialMenu.css
@@ -1,15 +1,3 @@
-:root {
-  --orb-color: var(--pink, #ff74de);
-  --rm-bg: color-mix(in srgb, var(--orb-color) 8%, var(--glass, rgba(14, 16, 22, 0.36)));
-  --rm-bg-hover: color-mix(in srgb, var(--orb-color) 14%, var(--glass, rgba(14, 16, 22, 0.36)));
-  --rm-border: var(--stroke-2);
-  --rm-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
-  --rm-shadow-hover: 0 12px 28px rgba(0, 0, 0, 0.35);
-  --rm-blur: var(--orb-blur, 14px);
-  --rm-ink: var(--ink);
-  --rm-ring: var(--orb-color);
-}
-
 .rbtn {
   position: absolute;
   width: 40px;
@@ -17,25 +5,27 @@
   border-radius: 9999px;
   display: grid;
   place-items: center;
-  background: var(--rm-bg);
-  border: 1px solid var(--rm-border);
-  color: var(--rm-ink);
+  background: var(--orb-bg);
+  border: 1px solid var(--orb-border);
+  color: var(--orb-ink);
   cursor: pointer;
-  backdrop-filter: blur(var(--rm-blur)) saturate(140%);
+  backdrop-filter: blur(var(--orb-blur)) saturate(140%);
   transform-origin: center;
-  box-shadow: var(--rm-shadow);
+  box-shadow: var(--orb-shadow);
   transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
-    opacity 0.2s ease;
+    opacity 0.2s ease, filter 0.2s ease;
 }
 
 .rbtn:hover,
 .rbtn:focus-visible {
-  background: var(--rm-bg-hover);
-  box-shadow: var(--rm-shadow-hover);
+  background: var(--orb-bg-hover);
+  box-shadow: var(--orb-shadow-hover);
+  transform: scale(1.03);
+  filter: saturate(115%);
 }
 
 .rbtn:active {
-  transform: scale(0.94);
+  transform: scale(0.97);
 }
 
 .rm-label {
@@ -46,6 +36,6 @@
   border: 1px solid var(--stroke-2);
   color: var(--ink);
   font-size: 12px;
-  backdrop-filter: blur(var(--rm-blur)) saturate(140%);
+  backdrop-filter: blur(var(--orb-blur)) saturate(140%);
   transform: translate(-50%, -50%);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -10,14 +10,24 @@
   --chip-ink: #fff;
   --radius: 14px;
   --shadow: 0 10px 30px rgba(11,15,26,.08), 0 1px 0 rgba(255,255,255,.7) inset;
-  --rm-bg: linear-gradient(145deg, rgba(14,16,22,.85), rgba(14,16,22,.65));
-  --rm-bg-hover: linear-gradient(145deg, rgba(14,16,22,.9), rgba(14,16,22,.7));
-  --rm-border: rgba(255,255,255,.2);
-  --rm-shadow: 0 8px 20px rgba(11,15,26,.25);
-  --rm-shadow-hover: 0 12px 28px rgba(11,15,26,.35);
-  --rm-blur: 14px;
-  --rm-ink: #fff;
-  --rm-ring: #ff74de;
+  --orb-bg: linear-gradient(145deg, rgba(14,16,22,.85), rgba(14,16,22,.65));
+  --orb-bg-hover: linear-gradient(145deg, rgba(14,16,22,.9), rgba(14,16,22,.7));
+  --orb-border: rgba(255,255,255,.2);
+  --orb-shadow: 0 8px 20px rgba(11,15,26,.25);
+  --orb-shadow-hover: 0 12px 28px rgba(11,15,26,.35);
+  --orb-blur: 14px;
+  --orb-ink: #fff;
+  --orb-ring: #ff74de;
+
+  /* Deprecated rm variables for backwards compatibility */
+  --rm-bg: var(--orb-bg);
+  --rm-bg-hover: var(--orb-bg-hover);
+  --rm-border: var(--orb-border);
+  --rm-shadow: var(--orb-shadow);
+  --rm-shadow-hover: var(--orb-shadow-hover);
+  --rm-blur: var(--orb-blur);
+  --rm-ink: var(--orb-ink);
+  --rm-ring: var(--orb-ring);
 }
 
 *{ box-sizing:border-box; }


### PR DESCRIPTION
## Summary
- align root theme variables with new `--orb-*` tokens and alias deprecated `--rm-*`
- update radial menu styles to consume `--orb-*` tokens
- adjust radial menu hover/active states to match Assistant orb

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f6ccd36e48321a42a4f93e0900f10