### PR TITLE
refactor: themable assistant orb

### DIFF
--- a/src/components/AssistantOrb.css
+++ b/src/components/AssistantOrb.css
@@ -1,10 +1,3 @@
-:root {
-  /* Assistant orb theme tokens */
-  --orb-size: 76px;
-  --orb-color: var(--pink, #ff74de);
-  --orb-blur: 14px;
-}
-
 .assistant-orb {
   position: fixed;
   width: var(--orb-size);
@@ -15,16 +8,9 @@
   place-items: center;
   cursor: grab;
   overflow: hidden;
-  background: radial-gradient(
-    120% 120% at 30% 30%,
-    #fff,
-    color-mix(in srgb, var(--orb-color) 45%, transparent) 60%,
-    var(--orb-color)
-  );
-  box-shadow:
-    0 12px 30px rgba(0, 0, 0, 0.35),
-    0 0 0 8px color-mix(in srgb, var(--orb-color) 25%, transparent);
-  backdrop-filter: blur(var(--orb-blur)) saturate(140%);
+  background: var(--orb-bg);
+  box-shadow: var(--orb-shadow);
+  backdrop-filter: blur(14px) saturate(140%);
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
   touch-action: none;
 }
@@ -54,7 +40,8 @@
   position: absolute;
   inset: -4px;
   border-radius: 50%;
-  box-shadow: inset 0 0 24px rgba(255, 255, 255, 0.55);
+  box-shadow: inset 0 0 24px var(--orb-ring);
+  filter: blur(4px);
 }
 
 .assistant-orb.mic .assistant-orb__ring {
@@ -63,7 +50,7 @@
 
 @keyframes orb-ping {
   0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--orb-color) 30%, transparent 70%);
+    box-shadow: 0 0 0 0 var(--orb-ring);
   }
   100% {
     box-shadow: 0 0 0 28px rgba(0, 0, 0, 0);

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,18 @@
   --rm-blur: 14px;
   --rm-ink: #fff;
   --rm-ring: #ff74de;
+  --orb-size: 76px;
+  --orb-ring: color-mix(in srgb, var(--rm-ring) 25%, transparent);
+  --orb-shadow: 0 12px 30px rgba(0,0,0,.35), 0 0 0 8px var(--orb-ring);
+  --orb-bg: radial-gradient(120% 120% at 30% 30%, rgba(255,255,255,.9), var(--orb-ring) 60%, var(--rm-ring));
+}
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --orb-ring: color-mix(in srgb, var(--rm-ring) 35%, transparent);
+    --orb-shadow: 0 12px 30px rgba(0,0,0,.65), 0 0 0 8px var(--orb-ring);
+    --orb-bg: radial-gradient(120% 120% at 30% 30%, rgba(20,24,32,.85), var(--orb-ring) 60%, var(--rm-ring));
+  }
 }
 
 *{ box-sizing:border-box; }


### PR DESCRIPTION
## Summary
- add orb theme variables and dark-mode overrides
- restyle AssistantOrb to use new variables for size, background, ring and shadow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6cc6ebbc83218e9437dd7c5d908c