### PR TITLE
Set up React Router with basic page routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,18 @@
 // src/App.tsx
 import React from "react";
-import Shell from "./components/Shell";
+import { Routes, Route } from "react-router-dom";
+import Feed from "./pages/Feed";
+import World from "./pages/World";
+import Settings from "./pages/Settings";
 import "./styles.css"; // global reset/theme (includes your orb/chat/portal CSS)
 
 export default function App() {
-  return <Shell />;
+  return (
+    <Routes>
+      <Route path="/" element={<Feed />} />
+      <Route path="/feed" element={<Feed />} />
+      <Route path="/world" element={<World />} />
+      <Route path="/settings" element={<Settings />} />
+    </Routes>
+  );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,15 @@
 // src/main.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/*" element={<App />} />
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>,
 );

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import Shell from "../components/Shell";
+
+export default function Feed() {
+  return <Shell />;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export default function Settings() {
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Settings</h1>
+      <p>Settings page content goes here.</p>
+    </div>
+  );
+}

--- a/src/pages/World.tsx
+++ b/src/pages/World.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import WorldScreen from "../components/WorldScreen";
+
+export default function World() {
+  const navigate = useNavigate();
+  return <WorldScreen onBack={() => navigate("/feed")} />;
+}


### PR DESCRIPTION
## Summary
- wrap app in `BrowserRouter` and mount router root
- add routing for feed, world, and settings pages
- create placeholder pages for feed, world, and settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6d88dfd8832186da7abccb7024ab