### PR TITLE
fix: guard window access in share handler

### DIFF
--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -121,7 +121,12 @@ export default function InfiniteFeed({
                 className="pc-act"
                 data-drop="share"
                 title="Share"
-                onClick={() => sharePost(img.link || window.location.href, img.author)}
+                onClick={() =>
+                  sharePost(
+                    img.link || (typeof window !== "undefined" ? window.location.href : ""),
+                    img.author
+                  )
+                }
               >
                 <span className="ico share" /><span>Share</span>
               </button>


### PR DESCRIPTION
## Summary
- Safely access `window.location.href` in the share button handler by checking for `window`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed28a07208321a49e51157110ab40