### PR TITLE
Use ref to clear AvatarPortal timeout on unmount

### DIFF
--- a/src/components/AvatarPortal.tsx
+++ b/src/components/AvatarPortal.tsx
@@ -1,20 +1,23 @@
 // src/components/AvatarPortal.tsx
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import "./AvatarPortal.css";
 
 export default function AvatarPortal(){
   const [on, setOn] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout>;
     const off = bus.on("avatar-portal:open", () => {
       setOn(true);
-      timeoutId = setTimeout(() => setOn(false), 900);
+      timeoutRef.current = setTimeout(() => setOn(false), 900);
     });
 
     return () => {
       off();
-      clearTimeout(timeoutId);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
     };
   }, []);
   return on ? (


### PR DESCRIPTION
## Summary
- track AvatarPortal timeout via ref
- clear timeout on unmount to prevent stray state updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed28768d483218dddea74d6d28a29