### PR TITLE
Guard sidebar clearAll for non-browser environments

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -51,10 +51,11 @@ export default function Sidebar() {
   const [showKey, setShowKey] = useState<string | null>(null);
   const setKey = (k: keyof Keys, v: string) => setKeys({ ...keys, [k]: v });
   const clearAll = () => {
-    Object.keys(localStorage)
+    if (typeof window === "undefined") return;
+    Object.keys(window.localStorage)
       .filter(k => k.startsWith("sn."))
-      .forEach(k => localStorage.removeItem(k));
-    location.reload();
+      .forEach(k => window.localStorage.removeItem(k));
+    window.location.reload();
   };
 
   return (


### PR DESCRIPTION
## Summary
- Prevent Sidebar.clearAll from accessing browser-only APIs when `window` is undefined

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed282fce0832189cd125a2893be64