### PR TITLE
Handle SSR in withinSafe

### DIFF
--- a/src/components/PortalOrb.tsx
+++ b/src/components/PortalOrb.tsx
@@ -43,6 +43,9 @@ export default function PortalOrb({ onAnalyzeImage }: Props) {
   }, [pos]);
 
   function withinSafe(x: number, y: number) {
+    if (typeof window === "undefined") {
+      return { x, y };
+    }
     const w = window.innerWidth;
     const h = window.innerHeight;
     const size = 64;


### PR DESCRIPTION
## Summary
- avoid clamping PortalOrb position when rendering on the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed273601083219a6845b4697e4251