### PR TITLE
Use stable keys for PostCard image grid

### DIFF
--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -113,17 +113,20 @@ export default function PostCard({ post }: { post: Post }) {
         ) : imgCount > 1 ? (
           <>
             <div className={`pc-gallery pc-n${Math.min(4, imgCount)}`}>
-              {gridImages.map((src, i) => (
-                <img
-                  key={i}
-                  src={src}
-                  alt={post?.title || post?.author || "post"}
-                  loading="lazy"
-                  crossOrigin={isBlob(src) ? undefined : "anonymous"}
-                  className={`pc-tile ${imgReady[i] ? "ready" : ""}`}
-                  onLoad={() => onImgLoad(i)}
-                />
-              ))}
+              {gridImages.map((src, i) => {
+                const key = gridImages.indexOf(src) === i ? src : `${src}-${i}`;
+                return (
+                  <img
+                    key={key}
+                    src={src}
+                    alt={post?.title || post?.author || "post"}
+                    loading="lazy"
+                    crossOrigin={isBlob(src) ? undefined : "anonymous"}
+                    className={`pc-tile ${imgReady[i] ? "ready" : ""}`}
+                    onLoad={() => onImgLoad(i)}
+                  />
+                );
+              })}
             </div>
             {extra > 0 && <div className="pc-more">+{extra}</div>}
           </>


### PR DESCRIPTION
## Summary
- Ensure image grid uses stable `key` values derived from image URLs
- Append index when duplicate URLs occur to maintain unique keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed275ef648321ab8cf32d91c539e4