### PR TITLE
Refactor PortalOverlay timeout handling with useRef

### DIFF
--- a/src/components/PortalOverlay.tsx
+++ b/src/components/PortalOverlay.tsx
@@ -5,7 +5,7 @@ import bus from "../lib/bus";
 export default function PortalOverlay(){
   const ref = useRef<HTMLDivElement|null>(null);
   const [on, setOn] = useState(false);
-  let timer: number | null = null;
+  const timer = useRef<number | null>(null);
 
   useEffect(() => {
     const off = bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
@@ -14,13 +14,15 @@ export default function PortalOverlay(){
       el.style.setProperty("--px", `${x}px`);
       el.style.setProperty("--py", `${y}px`);
       setOn(true);
-      timer = window.setTimeout(() => setOn(false), 700);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = window.setTimeout(() => setOn(false), 700);
     });
     return () => {
-      if (timer) clearTimeout(timer);
+      if (timer.current) clearTimeout(timer.current);
       off();
     };
   }, []);
 
   return <div ref={ref} className={`portal-overlay${on ? " on": ""}`} />;
 }
+


### PR DESCRIPTION
## Summary
- use `useRef` for PortalOverlay timeout to avoid stale closures
- manage timer setup and cleanup with `timer.current`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed286c39883218493a13f14bde3bd