### PR TITLE
feat: centralize theme state

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import "./Sidebar.css";
 import bus from "../lib/bus";
+import { useTheme } from "../lib/useTheme";
 
 type Keys = { openai?: string; anthropic?: string; perplexity?: string; stability?: string; elevenlabs?: string; };
 
@@ -38,15 +39,14 @@ export default function Sidebar() {
   const [bio, setBio] = useLocal("sn.profile.bio", "I bend worlds with orbs and postcards.");
   const [avatar, setAvatar] = useLocal("sn.profile.avatar", "/avatar.jpg");
 
-  const [theme, setTheme] = useLocal<"dark"|"light">("sn.theme", "dark");
+  const [theme, setTheme] = useTheme();
   const [accent, setAccent] = useLocal("sn.accent", "#7c83ff");
   const [worldMode, setWorldMode] = useLocal<"orbs"|"matrix">("sn.world.mode", "orbs");
   const [orbCount, setOrbCount] = useLocal("sn.world.count", 64);
 
   useEffect(() => {
     document.documentElement.style.setProperty("--accent", accent);
-    document.documentElement.dataset.theme = theme;
-  }, [accent, theme]);
+  }, [accent]);
 
   const [keys, setKeys] = useLocal<Keys>("sn.keys", {});
   const [showKey, setShowKey] = useState<string | null>(null);

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,20 +1,10 @@
-import React, { useLayoutEffect, useRef, useState, useEffect } from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import bus from "../lib/bus";
+import { useTheme } from "../lib/useTheme";
 
 export default function Topbar() {
   const ref = useRef<HTMLElement | null>(null);
-  const [theme, setTheme] = useState(() =>
-    typeof window !== "undefined"
-      ? localStorage.getItem("theme") || "dark"
-      : "dark"
-  );
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      document.documentElement.setAttribute("data-theme", theme);
-      localStorage.setItem("theme", theme);
-    }
-  }, [theme]);
+  const [theme, setTheme] = useTheme();
 
   useLayoutEffect(() => {
     if (!ref.current) return;

--- a/src/lib/useTheme.ts
+++ b/src/lib/useTheme.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from "react";
+import { load, save } from "./storage";
+
+export type Theme = "dark" | "light";
+const THEME_KEY = "sn.theme";
+
+let currentTheme: Theme = load<Theme>(THEME_KEY, "dark");
+
+if (typeof document !== "undefined") {
+  document.documentElement.dataset.theme = currentTheme;
+}
+
+const listeners = new Set<() => void>();
+
+function setTheme(t: Theme) {
+  currentTheme = t;
+  save(THEME_KEY, t);
+  if (typeof document !== "undefined") {
+    document.documentElement.dataset.theme = t;
+  }
+  listeners.forEach(l => l());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, () => currentTheme);
+  return [theme, setTheme] as const;
+}


### PR DESCRIPTION
## Summary
- add shared `useTheme` hook that syncs `sn.theme` and applies `data-theme`
- refactor Topbar and Sidebar to consume global theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f831d9af483218c05d25ddd9cb5ee