### PR TITLE
test: cover topbar theme toggle and sidebar bus

### DIFF
--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+const handlers: Record<string, Function[]> = {};
+vi.mock("../lib/bus", () => ({
+  default: {
+    on: (event: string, fn: Function) => {
+      (handlers[event] ||= []).push(fn);
+      return () => {};
+    },
+    emit: (event: string, payload?: any) => {
+      handlers[event]?.forEach(h => h(payload));
+    },
+  },
+}));
+
+import Sidebar from "./Sidebar";
+import bus from "../lib/bus";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Sidebar", () => {
+  it("responds to bus events and UI controls", async () => {
+    const { getByLabelText, queryByLabelText } = render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+    // ensure listeners registered
+    await waitFor(() => expect(handlers["sidebar:open"]).toBeDefined());
+
+    expect(queryByLabelText(/Close sidebar/i)).toBeNull();
+
+    bus.emit("sidebar:open");
+    await waitFor(() => getByLabelText(/Close sidebar/i));
+
+    bus.emit("sidebar:close");
+    await waitFor(() => expect(queryByLabelText(/Close sidebar/i)).toBeNull());
+
+    bus.emit("sidebar:toggle");
+    await waitFor(() => getByLabelText(/Close sidebar/i));
+
+    fireEvent.click(getByLabelText(/Close sidebar/i));
+    await waitFor(() => expect(queryByLabelText(/Close sidebar/i)).toBeNull());
+
+    bus.emit("sidebar:open");
+    await waitFor(() => getByLabelText("Close"));
+    const closeBtn = getByLabelText("Close");
+    fireEvent.click(closeBtn);
+    await waitFor(() => expect(queryByLabelText(/Close sidebar/i)).toBeNull());
+  });
+});

--- a/src/components/Topbar.test.tsx
+++ b/src/components/Topbar.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, beforeAll, afterEach } from "vitest";
+import Topbar from "./Topbar";
+import bus from "../lib/bus";
+
+beforeAll(() => {
+  (global as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Topbar", () => {
+  it("emits sidebar:toggle when clicking brand orb", () => {
+    const emitSpy = vi.spyOn(bus, "emit");
+    const { getByRole } = render(<Topbar />);
+    const orb = getByRole("button", { name: /open brand menu/i });
+    fireEvent.click(orb);
+    expect(emitSpy).toHaveBeenCalledWith("sidebar:toggle");
+    emitSpy.mockRestore();
+  });
+
+  it("updates document data-theme when theme toggle is clicked", async () => {
+    const { getByRole } = render(<Topbar />);
+    const toggle = getByRole("button", { name: /toggle theme/i });
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(document.documentElement.dataset.theme).toBe("light"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Topbar tests for brand orb sidebar toggle and theme switching
- verify Sidebar responds to bus events and UI controls via mocked bus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f831b8e8883219cc8f812b8507e1c