### PR TITLE
Animate sidebar with smooth slide and scrim fade

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,6 +1,44 @@
-:root { --accent: #0A84FF; }
+/* Sidebar animations */
+:root {
+  --accent: #0A84FF;
+  --sb-duration: 0.28s;
+  --sb-ease: cubic-bezier(.18,.9,.22,1);
+  --sb-closed-transform: translateY(-8px) scale(.975);
+}
 
-.sb { position: fixed; top: 16px; left: 16px; z-index: 70; }
+.sb {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 70;
+  opacity: 0;
+  transform: var(--sb-closed-transform);
+  pointer-events: none;
+  transition:
+    transform var(--sb-duration) var(--sb-ease),
+    opacity var(--sb-duration) var(--sb-ease);
+}
+
+.sb.open {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+
+.sb-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.55);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--sb-duration) var(--sb-ease);
+}
+
+.sb-scrim.open {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 /* Floating avatar FAB removed */
 
@@ -16,11 +54,13 @@
   backdrop-filter: blur(30px) saturate(200%);
   box-shadow: 0 28px 64px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.05);
   padding: 14px;
-  animation: sbIn 0.28s cubic-bezier(.18,.9,.22,1) forwards;
 }
-@keyframes sbIn {
-  from { transform: translateY(-8px) scale(.975); opacity: 0; }
-  to   { transform: none; opacity: 1; }
+
+@media (prefers-reduced-motion: reduce) {
+  .sb,
+  .sb-scrim {
+    transition: none;
+  }
 }
 
 /* Sidebar header */

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -66,90 +66,93 @@ export default function Sidebar() {
 
   return (
     <>
-      {open && <div className="sb-scrim" onClick={() => setOpen(false)} aria-label="Close sidebar" />}
-      <aside className={`sb ${open ? "open" : ""}`}>
-        {open && (
-          <div className="sb-panel" role="dialog" aria-modal="true">
-            {/* Header */}
-            <div className="sb-head">
-              <button className="sb-x" onClick={() => setOpen(false)} aria-label="Close">✕</button>
-              <div className="sb-brand">
-                <span className="sb-orb" />
-                <span className="sb-logo">superNova</span>
+      <div
+        className={`sb-scrim ${open ? "open" : ""}`}
+        onClick={() => setOpen(false)}
+        aria-label="Close sidebar"
+        aria-hidden={!open}
+      />
+      <aside className={`sb ${open ? "open" : ""}`} aria-hidden={!open}>
+        <div className="sb-panel" role="dialog" aria-modal={open ? "true" : undefined}>
+          {/* Header */}
+          <div className="sb-head">
+            <button className="sb-x" onClick={() => setOpen(false)} aria-label="Close">✕</button>
+            <div className="sb-brand">
+              <span className="sb-orb" />
+              <span className="sb-logo">superNova</span>
+            </div>
+          </div>
+
+          <nav className="sb-nav" aria-label="Main">
+            <ul>
+              {pages.map(p => (
+                <li key={p.path}>
+                  <NavLink to={p.path} end>
+                    <span aria-hidden>{p.icon}</span>
+                    <span>{p.label}</span>
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+
+          {/* Profile card */}
+          <section className="card profile">
+            {/* ... profile avatar, name, handle inputs ... */}
+          </section>
+
+          {/* Appearance settings */}
+          <section className="card">
+            <header>Appearance</header>
+            <div className="grid two">
+              <div>
+                <label className="label">Theme</label>
+                <select className="input" value={theme} onChange={e => setTheme(e.target.value as any)}>
+                  <option value="dark">Dark</option>
+                  <option value="light">Light</option>
+                </select>
+              </div>
+              <div>
+                <label className="label">Accent</label>
+                <div className="swatches">
+                  {["#7c83ff","#ff74de","#00ffa2","#9efcff","#ffd166"].map(c => (
+                    <button
+                      key={c}
+                      className={`sw ${c===accent ? "on" : ""}`}
+                      style={{ background: c }}
+                      onClick={() => setAccent(c)}
+                      aria-label={c}
+                    />
+                  ))}
+                  <input className="input" value={accent} onChange={e => setAccent(e.target.value)} />
+                </div>
               </div>
             </div>
 
-            <nav className="sb-nav" aria-label="Main">
-              <ul>
-                {pages.map(p => (
-                  <li key={p.path}>
-                    <NavLink to={p.path} end>
-                      <span aria-hidden>{p.icon}</span>
-                      <span>{p.label}</span>
-                    </NavLink>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-
-            {/* Profile card */}
-            <section className="card profile">
-              {/* ... profile avatar, name, handle inputs ... */}
-            </section>
-
-            {/* Appearance settings */}
-            <section className="card">
-              <header>Appearance</header>
-              <div className="grid two">
-                <div>
-                  <label className="label">Theme</label>
-                  <select className="input" value={theme} onChange={e => setTheme(e.target.value as any)}>
-                    <option value="dark">Dark</option>
-                    <option value="light">Light</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="label">Accent</label>
-                  <div className="swatches">
-                    {["#7c83ff","#ff74de","#00ffa2","#9efcff","#ffd166"].map(c =>
-                      <button 
-                        key={c} 
-                        className={`sw ${c===accent ? "on" : ""}`} 
-                        style={{ background: c }} 
-                        onClick={() => setAccent(c)} 
-                        aria-label={c} 
-                      />
-                    )}
-                    <input className="input" value={accent} onChange={e => setAccent(e.target.value)} />
-                  </div>
-                </div>
+            <div className="grid two">
+              <div>
+                <label className="label">Background</label>
+                <select className="input" value={worldMode} onChange={e => setWorldMode(e.target.value as any)}>
+                  <option value="orbs">Orb Mesh</option>
+                  <option value="matrix">Matrix Drift</option>
+                </select>
               </div>
-
-              <div className="grid two">
-                <div>
-                  <label className="label">Background</label>
-                  <select className="input" value={worldMode} onChange={e => setWorldMode(e.target.value as any)}>
-                    <option value="orbs">Orb Mesh</option>
-                    <option value="matrix">Matrix Drift</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="label">Orb density</label>
-                  <input 
-                    className="input" type="range" min={16} max={160} step={4}
-                    value={orbCount} 
-                    onChange={e => setOrbCount(parseInt(e.target.value, 10))} 
-                  />
-                </div>
+              <div>
+                <label className="label">Orb density</label>
+                <input
+                  className="input" type="range" min={16} max={160} step={4}
+                  value={orbCount}
+                  onChange={e => setOrbCount(parseInt(e.target.value, 10))}
+                />
               </div>
-              <p className="hint">Changes apply instantly and persist on this device.</p>
-            </section>
+            </div>
+            <p className="hint">Changes apply instantly and persist on this device.</p>
+          </section>
 
-            {/* API Keys Vault, Integrations, Privacy, Danger Zone sections ... */}
+          {/* API Keys Vault, Integrations, Privacy, Danger Zone sections ... */}
 
-            <footer className="sb-foot">made with ✨</footer>
-          </div>
-        )}
+          <footer className="sb-foot">made with ✨</footer>
+        </div>
       </aside>
     </>
   );


### PR DESCRIPTION
## Summary
- add CSS variable-driven slide/fade animations for sidebar and backdrop
- always render sidebar elements to allow transitions
- respect `prefers-reduced-motion` by disabling transitions when requested

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f832a252083219ef864058d9967e1