### PR TITLE
feat: use BrandBadge in topbar

### DIFF
--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,10 +1,18 @@
 import React, { useLayoutEffect, useRef } from "react";
 import bus from "../lib/bus";
 import { useTheme } from "../lib/useTheme";
+import BrandBadge from "./BrandBadge";
 
 export default function Topbar() {
   const ref = useRef<HTMLElement | null>(null);
   const [theme, setTheme] = useTheme();
+
+  const handleEnterUniverse = () => {
+    const el = document.querySelector(".brand-dot") as HTMLElement | null;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    bus.emit("orb:portal", { x: r.left + r.width / 2, y: r.top + r.height / 2 });
+  };
 
   useLayoutEffect(() => {
     if (!ref.current) return;
@@ -20,37 +28,17 @@ export default function Topbar() {
 
   return (
     <header className="topbar" ref={ref}>
-      {/* 🔵 Brand orb with 2177 — click → portal burst, then sidebar */}
-      <button
-        className="topbar-orb"
-        onClick={(e) => {
-          const r = (e.currentTarget as HTMLButtonElement).getBoundingClientRect();
-          bus.emit("orb:portal", { x: r.left + r.width / 2, y: r.top + r.height / 2 });
-          bus.emit("sidebar:toggle");
-        }}
-        aria-label="Open brand menu"
-      >
-        <span className="topbar-orb-text">2177</span>
-      </button>
+      <BrandBadge onEnterUniverse={handleEnterUniverse} />
 
       <div className="topbar-title">superNova_2177</div>
 
       <div style={{ display: "flex", gap: 8 }}>
         <button
           className="topbar-menu-btn"
-          onClick={() =>
-            setTheme(theme === "dark" ? "light" : "dark")
-          }
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
           aria-label="Toggle theme"
         >
           {theme === "dark" ? "☀️" : "🌙"}
-        </button>
-        <button
-          className="topbar-menu-btn"
-          onClick={() => bus.emit("sidebar:toggle")}
-          aria-label="Menu"
-        >
-          ≡
         </button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- replace old topbar brand orb with BrandBadge
- remove duplicated sidebar toggle button and handle entering universe from badge

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f87359cf08321a7d12721576387ed