### PR TITLE
feat: add avatar portal splash

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -8,6 +8,7 @@ import Topbar from "./Topbar";
 import Sidebar from "./Sidebar";
 import PortalOverlay from "./PortalOverlay";
 import PostComposer from "./PostComposer";
+import AvatarPortal from "./AvatarPortal";
 
 export default function Shell() {
   return (
@@ -37,6 +38,7 @@ export default function Shell() {
 
       <ChatDock />
       <AssistantOrb />
+      <AvatarPortal />
     </>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -54,6 +54,16 @@ export default function Sidebar() {
   );
   const [avatar, setAvatar] = useLocal("sn.profile.avatar", "/avatar.jpg");
 
+  // Trigger the AvatarPortal splash whenever the avatar changes
+  const avatarChanged = useRef(false);
+  useEffect(() => {
+    if (avatarChanged.current) {
+      bus.emit("avatar-portal:open");
+    } else {
+      avatarChanged.current = true;
+    }
+  }, [avatar]);
+
   const [theme, setTheme] = useTheme();
   const [accent, setAccent] = useLocal("sn.accent", "#7c83ff");
   const [worldMode, setWorldMode] = useLocal<"orbs" | "matrix">(


### PR DESCRIPTION
## Summary
- Render AvatarPortal at the app shell so avatar updates trigger a splash overlay
- Emit avatar-portal event when the user's avatar changes in the sidebar profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f87324c58832184ff25e6e3aa4106