### PR TITLE
feat: add remix box

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -18,6 +18,7 @@ export default function PostCard({ post }: { post: Post }) {
   const [drawer, setDrawer] = useState(false);
   const [comments, setComments] = useState<string[]>([]);
   const [reactions, setReactions] = useState<string[]>([]);
+  const [remixOpen, setRemixOpen] = useState(false);
 
   useEffect(() => {
     const off1 = bus.on?.("post:comment", ({ id, body }) => {
@@ -173,7 +174,7 @@ export default function PostCard({ post }: { post: Post }) {
                       fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
               </svg>
             </button>
-            <button className="pc-act" aria-label="Remix" title="Remix" onClick={() => bus.emit?.("post:remix", { id: post.id })}>
+            <button className="pc-act" aria-label="Remix" title="Remix" onClick={() => setRemixOpen((s) => !s)}>
               <svg className="ico" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M4 4h8l2 3h6v13H4zM7 10h10M7 14h10"
                       fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
@@ -202,6 +203,13 @@ export default function PostCard({ post }: { post: Post }) {
           )}
         </div>
       </div>
+
+      {remixOpen && (
+        <div className="pc-remix-box" role="region" aria-label="Remix controls">
+          <div className="pc-empty">Remix area</div>
+          <button onClick={() => setRemixOpen(false)}>Close</button>
+        </div>
+      )}
 
       <div className="pc-drawer">
         <div className="pc-drawer-inner">

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -106,4 +106,25 @@
 .pc-addcmt{ display:flex; gap:8px; margin-top:10px; }
 .pc-addcmt input{ flex:1; height:36px; padding:0 10px; border-radius:10px; outline:none; background: rgba(16,18,28,.65); border:1px solid rgba(255,255,255,.16); color:#fff; }
 .pc-addcmt button{ height:36px; padding:0 12px; border-radius:10px; cursor:pointer; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.16); color:#fff; }
+.pc-remix-box{
+  margin-top:8px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  padding:8px 10px;
+  border-radius: var(--pc-radius);
+  background: var(--pc-frost-2);
+  border:1px solid var(--pc-stroke);
+  color: var(--pc-text);
+}
+.pc-remix-box button{
+  align-self:flex-end;
+  height:36px;
+  padding:0 12px;
+  border-radius:10px;
+  cursor:pointer;
+  background: rgba(255,255,255,.08);
+  border:1px solid rgba(255,255,255,.16);
+  color:#fff;
+}
 .pc-empty{ opacity:.7; }


### PR DESCRIPTION
## Summary
- add `remixOpen` state to toggle a remix panel
- show a simple remix box with close control
- style `.pc-remix-box` to match comment box material

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd0f960048321bd75cf965b68ce9a