### PR TITLE
Enable scrolling for PostCard drawer

### DIFF
--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -94,7 +94,7 @@
 .pc-dot.on{ background:#fff; }
 
 .pc-drawer{ max-height:0; overflow:hidden; transition:max-height .25s ease, opacity .18s ease, transform .18s ease; opacity:0; transform: translateY(-4px); background: rgba(14,16,24,.65); border-top:1px solid var(--pc-stroke); color:var(--pc-text); }
-.pc.dopen .pc-drawer{ max-height: 560px; opacity:1; transform:none; }
+.pc.dopen .pc-drawer{ max-height: min(80vh, 560px); overflow-y:auto; opacity:1; transform:none; }
 .pc-drawer-inner{ padding:12px 14px; }
 .pc-emoji-bar{ display:flex; flex-wrap:wrap; gap:6px; }
 .pc-emoji{ height:34px; min-width:34px; padding:0 6px; border-radius:999px; display:grid; place-items:center; font-size:18px; cursor:pointer; background: rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.12); }
@@ -104,6 +104,6 @@
 .pc-comments{ list-style:none; margin:8px 0 0; padding:0; display:grid; gap:6px; }
 .pc-comments li{ background: rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.12); padding:8px 10px; border-radius:10px; opacity:.95; }
 .pc-addcmt{ display:flex; gap:8px; margin-top:10px; }
-.pc-addcmt input{ flex:1; height:36px; padding:0 10px; border-radius:10px; outline:none; background: rgba(16,18,28,.65); border:1px solid rgba(255,255,255,.16); color:#fff; }
+.pc-addcmt input{ flex:1; height:36px; padding:0 10px; border-radius:10px; outline:none; background: rgba(16,18,28,.65); border:1px solid rgba(255,255,255,.16); color:#fff; font-size:16px; }
 .pc-addcmt button{ height:36px; padding:0 12px; border-radius:10px; cursor:pointer; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.16); color:#fff; }
 .pc-empty{ opacity:.7; }


### PR DESCRIPTION
## Summary
- Allow PostCard drawer to scroll with viewport-based max height
- Set comment input font size to 16px to avoid mobile zoom

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd295357c83219910908a58390fa1