### PR TITLE
feat: adjust sidebar for small screens

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -44,7 +44,8 @@
 
 /* Sidebar panel (glassmorphic dark theme) */
 .sb-panel {
-  width: 360px;
+  width: 100%;
+  max-width: 360px;
   max-height: calc(100vh - 32px);
   overflow: auto;
   border-radius: 24px;
@@ -54,6 +55,18 @@
   backdrop-filter: blur(30px) saturate(200%);
   box-shadow: 0 28px 64px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.05);
   padding: 14px;
+}
+
+@media (max-width: 400px) {
+  .sb {
+    top: 8px;
+    left: 8px;
+  }
+
+  .sb-panel {
+    max-height: calc(100vh - 16px);
+    padding: 10px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- make sidebar panel responsive with width:100% and max-width:360px
- add small screen media query to tighten padding and position

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fd28caf7c8321a5054006d3809db0