### PR TITLE
Center AvatarPortal animation and limit mobile scale

### DIFF
--- a/src/components/AvatarPortal.css
+++ b/src/components/AvatarPortal.css
@@ -8,21 +8,34 @@
   background: radial-gradient(120% 120% at 30% 30%, #fff, var(--orb-surface) 60%, var(--orb-color));
   filter: blur(0px);
   animation: apSplash .9s cubic-bezier(.2,.9,.1,1) forwards;
-  transform-origin: top left;
+  transform-origin: center;
 }
 .ap-ring{
   position:absolute; top:6px; left:6px; width:40px; height:40px; border-radius:999px;
   border: 2px solid rgba(255,255,255,.6);
   animation: apRing .9s ease-out forwards;
-  transform-origin: top left;
+  transform-origin: center;
 }
 @keyframes apSplash{
   0% { transform: scale(1); opacity:1; }
-  80% { transform: scale(30); opacity:.2; filter: blur(30px); }
-  100% { transform: scale(40); opacity:0; filter: blur(50px); }
+  80% { transform: scale(18); opacity:.2; filter: blur(30px); }
+  100% { transform: scale(25); opacity:0; filter: blur(50px); }
 }
 @keyframes apRing{
   0% { transform: scale(1); opacity:1; }
-  60% { transform: scale(26); opacity:.9; }
-  100% { transform: scale(40); opacity:0; }
+  60% { transform: scale(16); opacity:.9; }
+  100% { transform: scale(25); opacity:0; }
+}
+
+@media (min-width: 640px) {
+  @keyframes apSplash {
+    0% { transform: scale(1); opacity:1; }
+    80% { transform: scale(30); opacity:.2; filter: blur(30px); }
+    100% { transform: scale(40); opacity:0; filter: blur(50px); }
+  }
+  @keyframes apRing {
+    0% { transform: scale(1); opacity:1; }
+    60% { transform: scale(26); opacity:.9; }
+    100% { transform: scale(40); opacity:0; }
+  }
 }


### PR DESCRIPTION
## Summary
- Center the AvatarPortal splash and ring animations
- Reduce animation scale on phones and gate original size behind a `min-width: 640px` media query

## Testing
- `npm test`
- `node -e "const w=390,h=844,di=Math.sqrt(w*w+h*h);const size=40*25;console.log('overshoot',size-di);"`


------
https://chatgpt.com/codex/tasks/task_e_689fd285570883219c53a07a7442142e