### PR TITLE
Fix PDF iframe scaling for mobile

### DIFF
--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -107,7 +107,8 @@ export default function PostCard({ post }: { post: Post }) {
               src={pdf}
               title="PDF"
               onLoad={onMediaReady}
-              style={{ opacity: 0 }}
+              width="100%"
+              style={{ opacity: 0, height: "56vw" }}
             />
           ) : model3d ? (
             <model-viewer

--- a/src/components/feed/postcard.css
+++ b/src/components/feed/postcard.css
@@ -75,6 +75,11 @@
   opacity:0; transition:opacity .25s ease;
 }
 
+.pc-media iframe{
+  aspect-ratio: 4 / 5;
+  max-height: 80vh;
+}
+
 /* carousel (for multiple images) */
 .pc-carousel{
   display:grid; grid-auto-flow:column; grid-auto-columns:100%;


### PR DESCRIPTION
## Summary
- ensure PDF iframe fills width with proportional height
- add mobile-friendly aspect ratio and height limits for PDF iframe

## Testing
- `npm test`
- `npm run build`
- ⚠️ `Manual PDF check on iOS/Android browsers` (not run: environment lacks mobile browsers)


------
https://chatgpt.com/codex/tasks/task_e_689fe506d1b883219c6c5b4af87099e2