### PR TITLE
refactor: simplify bus cleanup

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -108,9 +108,12 @@ export default function AssistantOrb() {
 
   // feed context
   useEffect(() => {
-    const a = bus.on?.("feed:hover", (p: { post: Post }) => setCtxPost(p.post));
-    const b = bus.on?.("feed:select", (p: { post: Post }) => setCtxPost(p.post));
-    return () => { try { a?.(); } catch {}; try { b?.(); } catch {}; };
+    const offHover = bus.on?.("feed:hover", (p: { post: Post }) => setCtxPost(p.post));
+    const offSelect = bus.on?.("feed:select", (p: { post: Post }) => setCtxPost(p.post));
+    return () => {
+      offHover?.();
+      offSelect?.();
+    };
   }, []);
 
   // speech


### PR DESCRIPTION
## Summary
- remove silent try/catch around bus event unsubs in AssistantOrb
- ensure cleanup unsubscribes from hover/select events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe630b7c083218eb0b4d7df6755d8