### PR TITLE
chore: use vercel types for api handlers

### DIFF
--- a/api/openai-ping.ts
+++ b/api/openai-ping.ts
@@ -1,5 +1,7 @@
 // /api/openai-ping.ts
-export default async function handler(req: any, res: any) {
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
   const { apiKey } = (req.body || {});
   if (!apiKey) return res.status(400).json({ ok: false, error: "Missing apiKey" });

--- a/api/openai-quick-chat.ts
+++ b/api/openai-quick-chat.ts
@@ -1,5 +1,7 @@
 // /api/openai-quick-chat.ts
-export default async function handler(req: any, res: any) {
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "POST") return res.status(405).json({ ok: false, error: "Method not allowed" });
   const { apiKey } = (req.body || {});
   if (!apiKey) return res.status(400).json({ ok: false, error: "Missing apiKey" });

--- a/api/players.ts
+++ b/api/players.ts
@@ -1,7 +1,7 @@
 // /api/players.ts
-import type { NextApiRequest, NextApiResponse } from "next";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== "GET") {
     return res.status(405).json({ ok: false, error: "Method not allowed" });
   }


### PR DESCRIPTION
## Summary
- replace Next.js request/response types with `VercelRequest`/`VercelResponse`
- align API route handler signatures for consistency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe63489c88321ac311326ebd7a422