### PR TITLE
feat: add typed event bus

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -108,8 +108,8 @@ export default function AssistantOrb() {
 
   // feed context
   useEffect(() => {
-    const a = bus.on?.("feed:hover", (p: { post: Post }) => setCtxPost(p.post));
-    const b = bus.on?.("feed:select", (p: { post: Post }) => setCtxPost(p.post));
+    const a = bus.on?.("feed:hover", (p) => setCtxPost(p.post));
+    const b = bus.on?.("feed:select", (p) => setCtxPost(p.post));
     return () => { try { a?.(); } catch {}; try { b?.(); } catch {}; };
   }, []);
 

--- a/src/components/BrandBadge.tsx
+++ b/src/components/BrandBadge.tsx
@@ -11,7 +11,7 @@ export default function BrandBadge({ onEnterUniverse }: { onEnterUniverse: () =>
           className="brand-dot"
           aria-label="Toggle brand menu"
           onClick={() => setOpen(o => !o)}
-          onDoubleClick={() => bus.emit("sidebar:toggle", undefined)} /* bus.emit expects (event, payload) */
+          onDoubleClick={() => bus.emit("sidebar:toggle")}
         >
           <img
             src="/supernova.png"

--- a/src/components/PortalOverlay.tsx
+++ b/src/components/PortalOverlay.tsx
@@ -28,7 +28,7 @@ export default function PortalOverlay() {
 
   // Bus listener: position, trigger animation, and provide a timeout fallback.
   useEffect(() => {
-    const off = bus.on("orb:portal", ({ x, y }: { x: number; y: number }) => {
+    const off = bus.on("orb:portal", ({ x, y }) => {
       const el = ref.current;
       if (!el) return;
 

--- a/src/components/feed/InfiniteFeed.tsx
+++ b/src/components/feed/InfiniteFeed.tsx
@@ -49,7 +49,7 @@ export default function InfiniteFeed({
     const r = bus.on("feed:refresh", () => {
       setList([]); setItems([]); setPageInternal(1);
     });
-    const s = bus.on("feed:provider-change", (p?: { provider?: ProviderName; query?: string }) => {
+    const s = bus.on("feed:provider-change", (p) => {
       // parent can re-render with new props, but this adds a quick path
       if (p?.provider) (document.body.dataset as any).feedProvider = p.provider;
     });

--- a/src/lib/bus.test.ts
+++ b/src/lib/bus.test.ts
@@ -3,12 +3,12 @@ import { on, emit } from "./bus";
 
 describe("bus", () => {
   it("handles listener errors via callback", () => {
-    const off1 = on("evt", () => { throw new Error("boom"); });
+    const off1 = on("post:react", (_p) => { throw new Error("boom"); });
     let called = false;
-    const off2 = on("evt", () => { called = true; });
+    const off2 = on("post:react", (_p) => { called = true; });
 
     const errors: unknown[] = [];
-    emit("evt", undefined, (err) => errors.push(err));
+    emit("post:react", { id: 1, emoji: "👍" }, (err) => errors.push(err));
 
     expect(errors).toHaveLength(1);
     expect(called).toBe(true);
@@ -18,8 +18,8 @@ describe("bus", () => {
   });
 
   it("rethrows listener errors when no callback provided", () => {
-    const off = on("evt", () => { throw new Error("boom"); });
-    expect(() => emit("evt")).toThrow("boom");
+    const off = on("post:react", (_p) => { throw new Error("boom"); });
+    expect(() => emit("post:react", { id: 1, emoji: "🔥" })).toThrow("boom");
     off();
   });
 });

--- a/src/lib/bus.ts
+++ b/src/lib/bus.ts
@@ -1,31 +1,62 @@
 // src/lib/bus.ts
-type Handler = (payload?: any) => void;
-const listeners = new Map<string, Set<Handler>>();
+import type { ID, Post } from "../types";
+import type { WorldState } from "./world";
+import type { ProviderName } from "./imageProviders";
 
-export function on(event: string, handler: Handler) {
+export interface EventMap {
+  "avatar-portal:open": void;
+  "chat:add": { role: string; text: string };
+  "compose": void;
+  "feed:hover": { post: Post; rect: DOMRect };
+  "feed:select": { post: Post };
+  "feed:repost": ID;
+  "feed:refresh": void;
+  "feed:provider-change": { provider?: ProviderName; query?: string };
+  "feed:select-id": { id: ID };
+  "orb:portal": { x: number; y: number };
+  "post:comment": { id: ID; body: string };
+  "post:react": { id: ID; emoji: string };
+  "post:focus": { id: ID };
+  "post:remix": { id: ID };
+  "profile:open": { id: ID };
+  "sidebar:toggle": void;
+  "sidebar:open": void;
+  "sidebar:close": void;
+  "world:update": Partial<WorldState>;
+}
+
+type Handler<K extends keyof EventMap> = (payload: EventMap[K]) => void;
+const listeners = new Map<keyof EventMap, Set<Handler<any>>>();
+
+export function on<K extends keyof EventMap>(event: K, handler: Handler<K>) {
   if (!listeners.has(event)) listeners.set(event, new Set());
-  listeners.get(event)!.add(handler);
+  listeners.get(event)!.add(handler as Handler<any>);
   return () => off(event, handler);
 }
-export function off(event: string, handler: Handler) {
+
+export function off<K extends keyof EventMap>(event: K, handler: Handler<K>) {
   const handlers = listeners.get(event);
-  handlers?.delete(handler);
+  handlers?.delete(handler as Handler<any>);
   if (handlers && handlers.size === 0) listeners.delete(event);
 }
-export function emit(
-  event: string,
-  payload?: any,
-  onError?: (err: unknown) => void,
+
+export function emit<K extends keyof EventMap>(
+  event: K,
+  ...args: EventMap[K] extends undefined
+    ? [payload?: EventMap[K], onError?: (err: unknown) => void]
+    : [payload: EventMap[K], onError?: (err: unknown) => void]
 ) {
+  const [payload, onError] = args;
   const handlers = listeners.get(event);
   if (!handlers) return;
   for (const fn of handlers) {
     try {
-      fn(payload);
+      (fn as Handler<K>)(payload as EventMap[K]);
     } catch (e) {
       if (onError) onError(e);
       else throw e;
     }
   }
 }
+
 export default { on, off, emit };

--- a/src/three/BackgroundVoid.tsx
+++ b/src/three/BackgroundVoid.tsx
@@ -30,7 +30,7 @@ export default function BackgroundVoid() {
 
   // listen for updates from the orb
   useEffect(() => {
-    return bus.on("world:update", (patch: Partial<WorldState>) => {
+    return bus.on("world:update", (patch) => {
       setW((prev) => clampWorld({ ...prev, ...patch }));
     });
   }, []);


### PR DESCRIPTION
## Summary
- introduce `EventMap` interface for strongly typed bus events
- refactor `on`, `off` and `emit` to use generic event keys and payloads
- adjust components to emit events with proper payloads and add tests for typed dispatch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe65fe6cc8321a5a3af7075eb1792