### PR TITLE
feat: add repost API call

### DIFF
--- a/src/lib/repost.ts
+++ b/src/lib/repost.ts
@@ -1,9 +1,42 @@
 export type Platform = 'x' | 'facebook' | 'linkedin';
 
 /**
- * Placeholder repost implementation.
- * In a real app this would call the platform APIs.
+ * Repost content to a social platform.
+ *
+ * In development this will simply log the repost action. In production it will
+ * call a backend endpoint responsible for interacting with the actual platform
+ * APIs (X, Facebook, LinkedIn).
+ *
+ * @param platform The platform to repost to.
+ * @param content The message or content to share.
+ * @returns `true` when the request succeeds, otherwise `false`.
  */
-export async function repost(platform: Platform, content: string) {
-  console.log(`Reposting to ${platform}: ${content}`);
+export async function repost(
+  platform: Platform,
+  content: string
+): Promise<boolean> {
+  try {
+    if (import.meta.env.PROD) {
+      const res = await fetch(`/api/repost/${platform}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ content }),
+      });
+
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+    } else {
+      // eslint-disable-next-line no-console -- helpful during development
+      console.log(`Reposting to ${platform}: ${content}`);
+    }
+
+    return true;
+  } catch (err) {
+    // eslint-disable-next-line no-console -- surface error for debugging
+    console.error('Repost failed', err);
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- replace stubbed `repost` with function that calls backend endpoint in production
- add error handling and return boolean success indicator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe6a68a508321a2a2284eed50a6d5