### PR TITLE
feat: expand sidebar navigation

### DIFF
--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -96,6 +96,7 @@
 
 .sb-nav { margin-bottom: 12px; }
 .sb-nav ul { list-style: none; display: flex; gap: 8px; padding: 0; }
+.sb-nav a,
 .sb-nav button {
   display: flex;
   align-items: center;
@@ -105,12 +106,23 @@
   background: none;
   border: none;
   color: inherit;
+  text-decoration: none;
   cursor: pointer;
 }
-.sb-nav button.active { background: rgba(255,255,255,.1); }
+.sb-nav a:hover,
+.sb-nav a.active,
+.sb-nav button:hover,
+.sb-nav button.active {
+  background: rgba(255,255,255,.1);
+}
+.sb-nav a:focus-visible,
 .sb-nav button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+.sb-nav-premium ul {
+  flex-direction: column;
 }
 
 .card { /* ...unchanged card styles... */ }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -88,6 +88,10 @@ export default function Sidebar() {
 
   const pages = [
     { label: "Home", path: "/", icon: "🏠" },
+    { label: "Feed", path: "/feed", icon: "📰" },
+    { label: "Chat", path: "/chat", icon: "💬" },
+    { label: "Messages", path: "/messages", icon: "✉️" },
+    { label: "Voting", path: "/voting", icon: "🗳️" },
     { label: "Profile", path: "/profile", icon: "👤" },
     { label: "Settings", path: "/settings", icon: "⚙️" },
   ];
@@ -168,6 +172,36 @@ export default function Sidebar() {
                     </NavLink>
                   </li>
                 ))}
+              </ul>
+            </nav>
+          </section>
+
+          <section className="card">
+            <header>Premium features</header>
+            <nav className="sb-nav sb-nav-premium" aria-label="Premium features">
+              <ul>
+                <li>
+                  <NavLink
+                    to="/music"
+                    className={({ isActive }) => (isActive ? "active" : "")}
+                    onClick={() => setOpen(false)}
+                    aria-label="Music"
+                  >
+                    <span aria-hidden>🎵</span>
+                    <span>Music</span>
+                  </NavLink>
+                </li>
+                <li>
+                  <NavLink
+                    to="/agents"
+                    className={({ isActive }) => (isActive ? "active" : "")}
+                    onClick={() => setOpen(false)}
+                    aria-label="Agents"
+                  >
+                    <span aria-hidden>🤖</span>
+                    <span>Agents</span>
+                  </NavLink>
+                </li>
               </ul>
             </nav>
           </section>


### PR DESCRIPTION
## Summary
- extend sidebar navigation with Feed, Chat, Messages, and Voting links
- add dedicated premium features section for Music and Agents
- style nav links for consistent spacing and hover states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fe9abefe08321942887258b524614