### PR TITLE
feat: add poll editor to post composer

### DIFF
--- a/src/components/PostComposer.css
+++ b/src/components/PostComposer.css
@@ -119,6 +119,53 @@
   cursor: pointer;
 }
 
+.composer__poll{
+  margin-top: 10px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid var(--stroke-2);
+  background: rgba(255,255,255,.04);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.composer__poll-option{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.composer__poll-question,
+.composer__poll-option-input{
+  flex: 1;
+  height: 36px;
+  padding: 0 10px;
+  border-radius: 10px;
+  border: 1px solid var(--stroke-2);
+  background: rgba(255,255,255,.04);
+  color: var(--ink);
+}
+
+.composer__poll-remove,
+.composer__poll-add,
+.composer__poll-cancel,
+.composer__poll-done{
+  height: 36px;
+  padding: 0 10px;
+  border-radius: 10px;
+  border: 1px solid var(--stroke-2);
+  background: rgba(255,255,255,.06);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.composer__poll-actions{
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 /* Make videos follow the same sizing as images inside cards */
 .post-media img,
 .post-media video {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,10 @@ export type Post = {
   pdf?: string;         // optional PDF URL (blob:/remote)
   model3d?: string;     // optional 3D model URL (blob:/remote)
   link?: string;        // optional external link being shared
+  poll?: {
+    question: string;
+    options: string[];
+  };
 };
 
 export type AssistantMessage = {


### PR DESCRIPTION
## Summary
- add poll editor with question and dynamic options
- allow composing polls from toolbar and include in new posts
- style poll controls to match existing composer aesthetics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fea9595f083219a0db9376a411b5a