### PR TITLE
fix: hydrate feed from injected posts

### DIFF
--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -11,10 +11,19 @@ const PRELOAD_PX = 800;
 
 export default function Feed() {
   const posts = useFeedStore((s) => s.posts);
+  const setPosts = useFeedStore((s) => s.setPosts);
   const [limit, setLimit] = useState(PAGE);
   const limitRef = useRef(limit);
   const visible = useMemo(() => posts.slice(0, limit), [posts, limit]);
   const ref = useRef<HTMLDivElement | null>(null);
+
+  // hydrate posts from global injection if available
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const injected = (window as any).__SN_POSTS__ as Post[] | undefined;
+      if (Array.isArray(injected) && injected.length) setPosts(injected);
+    }
+  }, [setPosts]);
 
   useEffect(() => {
     limitRef.current = limit;


### PR DESCRIPTION
## Summary
- ensure feed picks up globally injected posts at runtime

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fed0831d883218c292b0986e9c8f5