### PR TITLE
fix: ensure feed renders in shell

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -22,18 +22,12 @@ export default function Shell() {
       <Sidebar />
       <PortalOverlay />
 
-      {/* IMPORTANT: use the same classes the feed CSS targets */}
-      <main
-        className="content-viewport feed-wrap"
-        // topbar pushes the scroller down (Topbar sets --topbar-h)
-        style={{ paddingTop: "var(--topbar-h, 56px)" }}
-      >
-        {/* keep the composer inside the feed grid width */}
-        <div className="feed-content" style={{ padding: "12px 0" }}>
-          <PostComposer />
-        </div>
-
-        <Feed />
+      <main>
+        <Feed style={{ paddingTop: "var(--topbar-h, 56px)" }}>
+          <div style={{ padding: "12px 0" }}>
+            <PostComposer />
+          </div>
+        </Feed>
       </main>
 
       <ChatDock />

--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -9,7 +9,12 @@ import "./Feed.css";
 const PAGE = 9;
 const PRELOAD_PX = 800;
 
-export default function Feed() {
+interface FeedProps {
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+}
+
+export default function Feed({ children, style }: FeedProps) {
   const posts = useFeedStore((s) => s.posts);
   const [limit, setLimit] = useState(PAGE);
   const limitRef = useRef(limit);
@@ -61,9 +66,10 @@ export default function Feed() {
   }, [posts]);
 
   return (
-    <div ref={ref} className="content-viewport">
+    <div ref={ref} className="content-viewport" style={style}>
       <div className="feed-wrap">
         <div className="feed-content">
+          {children}
           {visible.length ? (
             visible.map((p) => <PostCard key={String(p.id)} post={p} />)
           ) : (


### PR DESCRIPTION
## Summary
- allow Feed component to accept children and style props
- mount Feed directly in Shell with PostComposer as child to avoid nested content wrappers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fed0831d883218c292b0986e9c8f5