### PR TITLE
feat: add poll voting

### DIFF
--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -49,12 +49,10 @@ export default function PostCard({ post }: { post: Post }) {
       if (String(id) !== String(post.id)) return;
       setComments((s) => [body, ...s]);
     });
-    const off3 = bus.on?.("post:vote", ({ id, option }) => {
+    const off3 = bus.on?.("post:vote", ({ id, optionIndex }) => {
       if (String(id) !== String(post.id)) return;
       setPollOpts((opts) =>
-        opts.map((o) =>
-          String(o.id) === String(option) ? { ...o, votes: o.votes + 1 } : o,
-        ),
+        opts.map((o, i) => (i === Number(optionIndex) ? { ...o, votes: o.votes + 1 } : o)),
       );
     });
     return () => {
@@ -116,10 +114,10 @@ export default function PostCard({ post }: { post: Post }) {
     try { await navigator.clipboard.writeText(url); } catch {}
   }
 
-  const handleVote = (optId: string) => {
+  const handleVote = (optId: string, index: number) => {
     if (voted) return;
     setVoted(optId);
-    bus.emit?.("post:vote", { id: post.id, option: optId });
+    bus.emit?.("post:vote", { id: post.id, optionIndex: index });
   };
 
   const totalVotes = pollOpts.reduce((sum, o) => sum + o.votes, 0);
@@ -206,11 +204,11 @@ export default function PostCard({ post }: { post: Post }) {
         {pollOpts.length > 0 && (
           <div className="pc-poll">
             {!voted
-              ? pollOpts.map((o) => (
+              ? pollOpts.map((o, i) => (
                   <button
                     key={o.id}
                     className="pc-poll-option"
-                    onClick={() => handleVote(o.id)}
+                    onClick={() => handleVote(o.id, i)}
                   >
                     {o.text}
                   </button>

--- a/src/lib/feedStore.test.ts
+++ b/src/lib/feedStore.test.ts
@@ -28,4 +28,16 @@ describe("usePaginatedPosts", () => {
     act(() => result.current.addPost({ id: 4, title: "four" } as any));
     expect(result.current.posts[0].id).toBe(4);
   });
+
+  it("increments poll votes via vote action", () => {
+    const { result } = renderHook(() => useFeedStore());
+    act(() =>
+      result.current.setPosts([
+        { id: 5, poll: { question: "q", options: ["a", "b"] } } as any,
+      ]),
+    );
+    act(() => result.current.vote(5, 1));
+    const opts = (result.current.posts[0].poll?.options as any[]) || [];
+    expect(opts[1]).toMatchObject({ text: "b", votes: 1 });
+  });
 });

--- a/src/lib/feedStore.ts
+++ b/src/lib/feedStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import type { Post } from "../types";
+import type { ID, Post } from "../types";
+import bus from "./bus";
 import { demoPosts } from "./placeholders";
 
 const injected =
@@ -15,13 +16,31 @@ interface FeedState {
   posts: Post[];
   setPosts: (posts: Post[]) => void;
   addPost: (post: Post) => void;
+  vote: (postId: ID, optionIndex: number) => void;
 }
 
 export const useFeedStore = create<FeedState>((set) => ({
   posts: initialPosts,
   setPosts: (posts) => set({ posts }),
   addPost: (post) => set((s) => ({ posts: [post, ...s.posts] })),
+  vote: (postId, optionIndex) =>
+    set((state) => ({
+      posts: state.posts.map((p) => {
+        if (String(p.id) !== String(postId)) return p;
+        if (!p.poll) return p;
+        const options = (p.poll.options as any[]).map((o: any) =>
+          typeof o === "string" ? { text: o, votes: 0 } : { ...o, votes: Number(o.votes) || 0 },
+        );
+        const opt = options[optionIndex];
+        if (opt) options[optionIndex] = { ...opt, votes: (opt.votes || 0) + 1 };
+        return { ...p, poll: { ...p.poll, options } };
+      }),
+    })),
 }));
+
+bus.on?.("post:vote", ({ id, optionIndex }: { id: ID; optionIndex: number }) => {
+  useFeedStore.getState().vote(id, optionIndex);
+});
 
 export function usePaginatedPosts(page: number, pageSize: number) {
   return useFeedStore((state) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export type Post = {
   link?: string;        // optional external link being shared
   poll?: {
     question: string;
-    options: string[];
+    options: Array<string | { text: string; votes: number }>;
   };
 };
 


### PR DESCRIPTION
## Summary
- allow poll options to carry vote counts
- add FeedState.vote and bus listener to sync poll votes
- emit and handle option index when voting in PostCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fedcc29548321aa9bac2fa1aa8368