### PR TITLE
Add ErrorBoundary for Shell component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
 // src/App.tsx
 import React from "react";
 import Shell from "./components/Shell";
+import ErrorBoundary from "./components/ErrorBoundary";
 import "./styles.css"; // global reset/theme (includes your orb/chat/portal CSS)
 
 export default function App() {
-  return <Shell />;
+  return (
+    <ErrorBoundary>
+      <Shell />
+    </ErrorBoundary>
+  );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+type Props = { children?: React.ReactNode };
+type State = { hasError: boolean };
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
+    // Log error to console or send to monitoring service
+    console.error("Uncaught error:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div role="alert">Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,4 +7,6 @@ export { default as Feed } from "./Feed";
 // ...or directly:
 // export { default as Feed } from "./feed/Feed";
 
+export { default as ErrorBoundary } from "./ErrorBoundary";
+
 export type { Post } from "../types";


### PR DESCRIPTION
## Summary
- introduce ErrorBoundary component to catch runtime errors and render fallback UI
- wrap Shell with ErrorBoundary to prevent uncaught errors from crashing the app
- export ErrorBoundary from components index for reuse

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fefcb35488321b2134b3ff8b96e5c