### PR TITLE
chore: handle model viewer load errors

### DIFF
--- a/src/lib/ensureModelViewer.ts
+++ b/src/lib/ensureModelViewer.ts
@@ -9,6 +9,14 @@ export function ensureModelViewer(): Promise<void> {
   // Lazy-load the model-viewer element from the npm package. This avoids
   // injecting scripts at runtime and ensures a single Three.js instance is
   // used across the app.
-  loading = import("@google/model-viewer").then(() => {});
+  loading = (async () => {
+    try {
+      await import("@google/model-viewer");
+    } catch (error) {
+      loading = null;
+      console.error(error);
+      throw error;
+    }
+  })();
   return loading;
 }


### PR DESCRIPTION
## Summary
- wrap model viewer dynamic import in try/catch
- reset loading flag and log errors on failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fefd769fc832188c94c7a38d4f0cc