### PR TITLE
chore: pin node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "npm@10",
   "engines": {
-    "node": ">=20"
+    "node": "20.x"
   },
   "overrides": {
     "three": "0.172.0"


### PR DESCRIPTION
## Summary
- pin Node.js engine to the 20.x series for Vercel deployments

## Testing
- `npm test`
- `VERCEL_TOKEN= npx --yes vercel@latest deploy --prod --yes` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_689fefd59b7483218d33f5856279de4b