### PR TITLE
Add global error boundary for app

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+// src/components/ErrorBoundary.tsx
+import React, { ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_error: Error): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" style={{ padding: "2rem", textAlign: "center" }}>
+          <h1>Something went wrong.</h1>
+          <p>Please try reloading the page.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import ErrorBoundary from "./components/ErrorBoundary";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </ErrorBoundary>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add an `ErrorBoundary` component with `getDerivedStateFromError` and `componentDidCatch`
- wrap `<BrowserRouter><App/></BrowserRouter>` with the new error boundary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fefd90a2883219766fd6943d02cac