### PR TITLE
handle model-viewer import failures

### DIFF
--- a/src/lib/ensureModelViewer.ts
+++ b/src/lib/ensureModelViewer.ts
@@ -9,6 +9,11 @@ export function ensureModelViewer(): Promise<void> {
   // Lazy-load the model-viewer element from the npm package. This avoids
   // injecting scripts at runtime and ensures a single Three.js instance is
   // used across the app.
-  loading = import("@google/model-viewer").then(() => {});
+  loading = import("@google/model-viewer")
+    .then(() => {})
+    .catch((e) => {
+      console.error("model-viewer failed to load", e);
+      return Promise.reject(e);
+    });
   return loading;
 }


### PR DESCRIPTION
## Summary
- log and rethrow errors from `@google/model-viewer` dynamic import to surface load issues

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff0a5fcc48321860830e0d9faf61e