### PR TITLE
Handle model viewer import errors

### DIFF
--- a/src/lib/ensureModelViewer.ts
+++ b/src/lib/ensureModelViewer.ts
@@ -9,6 +9,19 @@ export function ensureModelViewer(): Promise<void> {
   // Lazy-load the model-viewer element from the npm package. This avoids
   // injecting scripts at runtime and ensures a single Three.js instance is
   // used across the app.
-  loading = import("@google/model-viewer").then(() => {});
+  const load = async (attempt = 0): Promise<void> => {
+    try {
+      await import("@google/model-viewer");
+    } catch (error) {
+      console.error("Failed to load @google/model-viewer", error);
+      if (attempt < 1) {
+        return load(attempt + 1);
+      }
+      const fallback = document.createElement("div");
+      fallback.textContent = "Model viewer failed to load.";
+      document.body.appendChild(fallback);
+    }
+  };
+  loading = load();
   return loading;
 }


### PR DESCRIPTION
## Summary
- handle `@google/model-viewer` dynamic import failures
- retry import once and render a fallback message when it fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ff0021c208321b89719217c3dda84