### PR TITLE
chore: upgrade three.js ecosystem to r172

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/model-viewer": "4.1.0",
-        "@react-three/drei": "9.100.0",
-        "@react-three/fiber": "8.15.19",
+        "@react-three/drei": "9.122.0",
+        "@react-three/fiber": "8.18.0",
         "@react-three/postprocessing": "2.19.1",
         "@react-three/xr": "^6.6.22",
         "@tanstack/react-virtual": "^3.13.12",
@@ -19,7 +19,8 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-router-dom": "^6.30.1",
-        "three": "0.172.0",
+        "three": "0.172.x",
+        "three-stdlib": "2.36.0",
         "zustand": "4.5.2"
       },
       "devDependencies": {
@@ -29,7 +30,7 @@
         "@types/node": "^24.3.0",
         "@types/react": "18.3.5",
         "@types/react-dom": "18.3.0",
-        "@types/three": "0.172.0",
+        "@types/three": "0.172.x",
         "@vercel/node": "^5.3.13",
         "@vitejs/plugin-react": "4.3.2",
         "jsdom": "^26.1.0",
@@ -39,7 +40,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=20"
+        "node": "20.11.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1214,9 +1215,9 @@
       }
     },
     "node_modules/@mediapipe/tasks-vision": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.8.tgz",
-      "integrity": "sha512-Rp7ll8BHrKB3wXaRFKhrltwZl1CiXGdibPxuWXvqGnKTnv8fqa/nvftYNuSbf+pbJWKYCXdBtYTITdAUTGGh0Q==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
       "license": "Apache-2.0"
     },
     "node_modules/@monogrid/gainmap-js": {
@@ -1314,28 +1315,27 @@
       }
     },
     "node_modules/@react-spring/animated": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.6.1.tgz",
-      "integrity": "sha512-ls/rJBrAqiAYozjLo5EPPLLOb1LM0lNVQcXODTC1SMtS6DbuBCPaKco5svFUQFMP2dso3O+qcC4k9FsKc0KxMQ==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/shared": "~9.6.1",
-        "@react-spring/types": "~9.6.1"
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@react-spring/core": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.6.1.tgz",
-      "integrity": "sha512-3HAAinAyCPessyQNNXe5W0OHzRfa8Yo5P748paPcmMowZ/4sMfaZ2ZB6e5x5khQI8NusOHj8nquoutd6FRY5WQ==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/animated": "~9.6.1",
-        "@react-spring/rafz": "~9.6.1",
-        "@react-spring/shared": "~9.6.1",
-        "@react-spring/types": "~9.6.1"
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
       },
       "funding": {
         "type": "opencollective",
@@ -1346,34 +1346,34 @@
       }
     },
     "node_modules/@react-spring/rafz": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.6.1.tgz",
-      "integrity": "sha512-v6qbgNRpztJFFfSE3e2W1Uz+g8KnIBs6SmzCzcVVF61GdGfGOuBrbjIcp+nUz301awVmREKi4eMQb2Ab2gGgyQ==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
       "license": "MIT"
     },
     "node_modules/@react-spring/shared": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.6.1.tgz",
-      "integrity": "sha512-PBFBXabxFEuF8enNLkVqMC9h5uLRBo6GQhRMQT/nRTnemVENimgRd+0ZT4yFnAQ0AxWNiJfX3qux+bW2LbG6Bw==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/rafz": "~9.6.1",
-        "@react-spring/types": "~9.6.1"
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@react-spring/three": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.6.1.tgz",
-      "integrity": "sha512-Tyw2YhZPKJAX3t2FcqvpLRb71CyTe1GvT3V+i+xJzfALgpk10uPGdGaQQ5Xrzmok1340DAeg2pR/MCfaW7b8AA==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
       "license": "MIT",
       "dependencies": {
-        "@react-spring/animated": "~9.6.1",
-        "@react-spring/core": "~9.6.1",
-        "@react-spring/shared": "~9.6.1",
-        "@react-spring/types": "~9.6.1"
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
       },
       "peerDependencies": {
         "@react-three/fiber": ">=6.0",
@@ -1382,43 +1382,44 @@
       }
     },
     "node_modules/@react-spring/types": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.6.1.tgz",
-      "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
       "license": "MIT"
     },
     "node_modules/@react-three/drei": {
-      "version": "9.100.0",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.100.0.tgz",
-      "integrity": "sha512-n0JGR5aKDHkmHn6ocB/DgRntff7eyMCnqZ6Tvs2Raw3TpfXztA7UK6ELo1nX/pmGWXEU8Mc7TduUWCnPzJYbTA==",
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@mediapipe/tasks-vision": "0.10.8",
-        "@react-spring/three": "~9.6.1",
-        "@use-gesture/react": "^10.2.24",
-        "camera-controls": "^2.4.2",
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
         "cross-env": "^7.0.3",
-        "detect-gpu": "^5.0.28",
+        "detect-gpu": "^5.0.56",
         "glsl-noise": "^0.0.0",
-        "maath": "^0.10.7",
-        "meshline": "^3.1.6",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
         "react-composer": "^5.0.3",
-        "stats-gl": "^2.0.0",
+        "stats-gl": "^2.2.8",
         "stats.js": "^0.17.0",
         "suspend-react": "^0.1.3",
-        "three-mesh-bvh": "^0.7.0",
-        "three-stdlib": "^2.29.4",
-        "troika-three-text": "^0.49.0",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
         "tunnel-rat": "^0.1.2",
-        "utility-types": "^3.10.0",
-        "uuid": "^9.0.1",
-        "zustand": "^3.7.1"
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
       },
       "peerDependencies": {
-        "@react-three/fiber": ">=8.0",
-        "react": ">=18.0",
-        "react-dom": ">=18.0",
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
         "three": ">=0.137"
       },
       "peerDependenciesMeta": {
@@ -1428,26 +1429,38 @@
       }
     },
     "node_modules/@react-three/drei/node_modules/zustand": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
-      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.7.tgz",
+      "integrity": "sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }
     },
     "node_modules/@react-three/fiber": {
-      "version": "8.15.19",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.15.19.tgz",
-      "integrity": "sha512-WbFU7T6485v8Onnp+JJnrzKFvvGP7OFyJmHlqXiXc2RcXl9Sax+ykJxiNwEXWjGjcgF9/KTfv0+pAVkP0vZlKg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
@@ -1457,7 +1470,7 @@
         "buffer": "^6.0.3",
         "its-fine": "^1.0.6",
         "react-reconciler": "^0.27.0",
-        "react-use-measure": "^2.1.1",
+        "react-use-measure": "^2.1.7",
         "scheduler": "^0.21.0",
         "suspend-react": "^0.1.3",
         "zustand": "^3.7.1"
@@ -1467,8 +1480,8 @@
         "expo-asset": ">=8.4",
         "expo-file-system": ">=11.0",
         "expo-gl": ">=11.0",
-        "react": ">=18.0",
-        "react-dom": ">=18.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
         "react-native": ">=0.64",
         "three": ">=0.133"
       },
@@ -5328,9 +5341,10 @@
       "license": "MIT"
     },
     "node_modules/three-mesh-bvh": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.6.tgz",
-      "integrity": "sha512-rCjsnxEqR9r1/C/lCqzGLS67NDty/S/eT6rAJfDvsanrIctTWdNoR4ZOGWewCB13h1QkVo2BpmC0wakj1+0m8A==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
       "license": "MIT",
       "peerDependencies": {
         "three": ">= 0.151.0"
@@ -5496,14 +5510,14 @@
       }
     },
     "node_modules/troika-three-text": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.49.1.tgz",
-      "integrity": "sha512-lXGWxgjJP9kw4i4Wh+0k0Q/7cRfS6iOME4knKht/KozPu9GcFA9NnNpRvehIhrUawq9B0ZRw+0oiFHgRO+4Wig==",
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.2",
-        "troika-three-utils": "^0.49.0",
-        "troika-worker-utils": "^0.49.0",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
         "webgl-sdf-generator": "1.1.1"
       },
       "peerDependencies": {
@@ -5511,18 +5525,18 @@
       }
     },
     "node_modules/troika-three-utils": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.49.0.tgz",
-      "integrity": "sha512-umitFL4cT+Fm/uONmaQEq4oZlyRHWwVClaS6ZrdcueRvwc2w+cpNQ47LlJKJswpqtMFWbEhOLy0TekmcPZOdYA==",
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
       "license": "MIT",
       "peerDependencies": {
         "three": ">=0.125.0"
       }
     },
     "node_modules/troika-worker-utils": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.49.0.tgz",
-      "integrity": "sha512-1xZHoJrG0HFfCvT/iyN41DvI/nRykiBtHqFkGaGgJwq5iXfIZFBiPPEHFpPpgyKM3Oo5ITHXP5wM2TNQszYdVg==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
       "license": "MIT"
     },
     "node_modules/ts-morph": {
@@ -5726,19 +5740,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "20.11.0"
   },
   "overrides": {
-    "three": "0.172.0"
+    "three": "0.172.x"
   },
   "scripts": {
     "dev": "vite",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@google/model-viewer": "4.1.0",
-    "@react-three/drei": "9.100.0",
-    "@react-three/fiber": "8.15.19",
+    "@react-three/drei": "9.122.0",
+    "@react-three/fiber": "8.18.0",
     "@react-three/postprocessing": "2.19.1",
     "@react-three/xr": "^6.6.22",
     "@tanstack/react-virtual": "^3.13.12",
@@ -28,7 +28,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "^6.30.1",
-    "three": "0.172.0",
+    "three": "0.172.x",
+    "three-stdlib": "2.36.0",
     "zustand": "4.5.2"
   },
   "devDependencies": {
@@ -38,7 +39,7 @@
     "@types/node": "^24.3.0",
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
-    "@types/three": "0.172.0",
+    "@types/three": "0.172.x",
     "@vercel/node": "^5.3.13",
     "@vitejs/plugin-react": "4.3.2",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Summary
- update three.js, @types/three and override to 0.172.x
- bump @react-three/fiber, @react-three/drei and add three-stdlib for r172 compatibility

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ff3d5adec83218d82e78cee2d2a2c