### PR TITLE
chore: ensure SPA routes fallback

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,6 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- rewrite all routes to `/` in Vercel config so unknown paths fall back to index.html

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ffdb7ef0483219f35c51fd311485a