### PR TITLE
warn when image provider key missing

### DIFF
--- a/src/lib/imageProviders.test.ts
+++ b/src/lib/imageProviders.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchImages } from "./imageProviders";
+
+describe("fetchImages", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("warns once and falls back to picsum when API key is missing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mockFetch = vi.fn(async (url: RequestInfo) => {
+      expect(String(url)).toContain("picsum.photos");
+      return {
+        ok: true,
+        json: async () => [
+          { id: 1, author: "a", url: "https://example.com", width: 100, height: 100 },
+        ],
+      } as any;
+    });
+    // @ts-ignore
+    global.fetch = mockFetch;
+
+    const r1 = await fetchImages({ provider: "unsplash", page: 1, perPage: 1 });
+    const r2 = await fetchImages({ provider: "unsplash", page: 1, perPage: 1 });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(r1.length).toBe(1);
+    expect(r2.length).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/src/lib/imageProviders.ts
+++ b/src/lib/imageProviders.ts
@@ -34,6 +34,15 @@ function getKey(name: string) {
   return undefined;
 }
 
+const warnedProviders = new Set<string>();
+function warnMissingKey(name: string) {
+  const upper = name.toUpperCase();
+  if (!warnedProviders.has(upper)) {
+    warnedProviders.add(upper);
+    console.warn(`VITE_${upper}_KEY is not set; falling back to placeholder images`);
+  }
+}
+
 /** PICSUM — no key needed */
 async function fetchPicsum(page: number, perPage: number): Promise<FeedImage[]> {
   const url = `https://picsum.photos/v2/list?page=${page}&limit=${perPage}`;
@@ -62,7 +71,10 @@ async function fetchPicsum(page: number, perPage: number): Promise<FeedImage[]> 
 /** UNSPLASH (optional) — needs access key (store as localStorage.sn.keys.unsplash) */
 async function fetchUnsplash(page: number, perPage: number, query?: string): Promise<FeedImage[]> {
   const key = getKey("unsplash");
-  if (!key) return []; // fall back to picsum in caller when empty
+  if (!key) {
+    warnMissingKey("unsplash");
+    return []; // fall back to picsum in caller when empty
+  }
   const base = query ? "https://api.unsplash.com/search/photos" : "https://api.unsplash.com/photos";
   const params = new URLSearchParams({
     page: String(page),
@@ -92,7 +104,10 @@ async function fetchUnsplash(page: number, perPage: number, query?: string): Pro
 /** PEXELS (optional) — needs key (store as localStorage.sn.keys.pexels) */
 async function fetchPexels(page: number, perPage: number, query?: string): Promise<FeedImage[]> {
   const key = getKey("pexels");
-  if (!key) return [];
+  if (!key) {
+    warnMissingKey("pexels");
+    return [];
+  }
   const base = query ? "https://api.pexels.com/v1/search" : "https://api.pexels.com/v1/curated";
   const params = new URLSearchParams({
     page: String(page),


### PR DESCRIPTION
## Summary
- warn once when Unsplash or Pexels API keys are absent, falling back to placeholder images
- add test ensuring missing keys trigger single warning and fallback

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ffdddf5d88321b27de026e0c36a4a