### PR TITLE
Use relative base path for Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',           // ← ADD THIS (critical for Vercel)
+  base: './',          // ← ADD THIS (critical for Vercel)
   build: {
     outDir: 'dist',    // ← ADD THIS (tells Vercel where built files are)
     rollupOptions: {


### PR DESCRIPTION
## Summary
- use `./` as Vite `base` so production build uses relative asset URLs

## Testing
- `npm run build`
- `npm test`
- `npm run preview` (verified with `curl -I http://localhost:5173`)


------
https://chatgpt.com/codex/tasks/task_e_689ffdbb483883219e3dabdd3578fe3f