### PR TITLE
style: improve error boundary fallback

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -20,7 +20,20 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
-      return <div role="alert">Something went wrong.</div>;
+      return (
+        <div
+          role="alert"
+          style={{
+            background: "#1e1e1e",
+            color: "#fff",
+            padding: "1rem",
+            textAlign: "center",
+          }}
+        >
+          <p><strong>Something went wrong.</strong></p>
+          <p>Try refreshing the page or contact support if the problem persists.</p>
+        </div>
+      );
     }
 
     return this.props.children;


### PR DESCRIPTION
## Summary
- style error boundary fallback with dark container, white text, and refresh instructions

## Testing
- `npm test`
- `npm run build`
- `npx vitest run --environment jsdom src/components/ErrorBoundary.fallback.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ffddc34e08321beb2565497b6fd10