### PR TITLE
feat: improve error boundary handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ You can deploy your new Vite project with a single command from your terminal us
 $ vercel
 ```
 
+## Viewing Console Errors on Vercel
+
+When debugging a production deployment, you can inspect runtime errors in two ways:
+
+1. Open your deployed site in the browser and use the browser's developer tools (**Console** tab) to see client-side errors.
+2. Visit your project on Vercel and open the **Logs** tab or run `vercel logs <deployment-url>` from the CLI to view server-side console output.
+
 ## Demo posts
 
 To preview the sample posts included in [`src/lib/placeholders.ts`](src/lib/placeholders.ts) after deploying to Vercel:

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { logError } from "../lib/logger";
 
 type Props = { children?: React.ReactNode };
-type State = { hasError: boolean };
+type State = { hasError: boolean; error?: unknown };
 
 export default class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -10,18 +10,23 @@ export default class ErrorBoundary extends React.Component<Props, State> {
     this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
     // Log error to console or send to monitoring service
     console.error("Uncaught error:", error, errorInfo);
     logError(error, errorInfo);
+    const sentry = (window as any).Sentry;
+    if (sentry && typeof sentry.captureException === "function") {
+      sentry.captureException(error, { extra: errorInfo });
+    }
   }
 
   render() {
     if (this.state.hasError) {
+      const message = this.state.error instanceof Error ? this.state.error.message : String(this.state.error);
       return (
         <div
           role="alert"
@@ -32,8 +37,17 @@ export default class ErrorBoundary extends React.Component<Props, State> {
             textAlign: "center",
           }}
         >
-          <p><strong>Something went wrong.</strong></p>
+          <p>
+            <strong>Something went wrong.</strong>
+          </p>
+          {this.state.error && <p>{message}</p>}
           <p>Try refreshing the page or contact support if the problem persists.</p>
+          <button
+            onClick={() => window.location.reload()}
+            style={{ marginTop: "1rem" }}
+          >
+            Reload
+          </button>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- display error message and reload button when ErrorBoundary catches an exception
- optionally report errors to monitoring services via `componentDidCatch`
- document how to view console errors on Vercel deployments

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install --force` *(fails: Override for three@0.172.0 conflicts with direct dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a000fdd9b083218705dbff1dadcea8