### PR TITLE
Ensure Vercel rewrites to index.html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,6 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- Direct all unmatched routes to `index.html` via Vercel config

## Testing
- `npm install --force` *(fails: Override for three@0.172.0 conflicts with direct dependency)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68a000f909888321b16c5dec4e2fb99d