### PR TITLE
Guard canvas image watchers for environments without observers

### DIFF
--- a/src/components/World3D.tsx
+++ b/src/components/World3D.tsx
@@ -92,9 +92,11 @@ export default function World3D() {
     let tint: RGB = { r: 48, g: 64, b: 140 };
     let tintTarget: RGB = { r: 48, g: 64, b: 140 };
 
-    // Watch visible post images
+    // Watch visible post images (guards for environments without observers)
+    const hasIO = typeof IntersectionObserver !== "undefined";
     let io: IntersectionObserver | null = null;
     const scanImages = () => {
+      if (!hasIO) return;
       io?.disconnect();
       const imgs = Array.from(document.querySelectorAll<HTMLImageElement>(".pc-media img"));
       if (!imgs.length) return;
@@ -106,13 +108,16 @@ export default function World3D() {
         const c = avgColor(best.target as HTMLImageElement);
         if (c) tintTarget = c;
       }, { threshold: [0, 0.25, 0.5, 0.75, 1] });
-      imgs.forEach(img => (img.complete ? io!.observe(img) : img.addEventListener("load", () => io!.observe(img), { once: true })));
+      imgs.forEach(img => (
+        img.complete ? io!.observe(img) : img.addEventListener("load", () => io!.observe(img), { once: true })
+      ));
     };
-    scanImages();
+    if (hasIO) scanImages();
 
     const feed = document.querySelector(".feed-content");
+    const hasMO = typeof MutationObserver !== "undefined";
     let mo: MutationObserver | null = null;
-    if (feed) {
+    if (feed && hasIO && hasMO) {
       mo = new MutationObserver(() => scanImages());
       mo.observe(feed, { childList: true, subtree: true });
     }


### PR DESCRIPTION
## Summary
- Skip image tinting watch logic when `IntersectionObserver` or `MutationObserver` aren't available
- Ensure world background canvas renders even in unsupported browsers

## Testing
- `npm install` *(fails: Override for three@0.172.0 conflicts with direct dependency)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a000ec41d48321883a12e2cf53f147