### PR TITLE
fix: send all routes to index.html

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,6 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- rewrite all routes to `index.html` for Vercel deployment

## Testing
- `npm test` (fails: vitest not found due to dependency conflict during installation)


------
https://chatgpt.com/codex/tasks/task_e_68a000febdb48321848d9af05bc9e640