### PR TITLE
Guard label texture creation for SSR

### DIFF
--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -84,8 +84,15 @@ function Portal() {
 }
 
 function makeLabelTexture(name: string, color = "#2eff7a") {
+  if (typeof document === "undefined") {
+    // During SSR, return an empty texture to avoid crashes
+    return new THREE.Texture();
+  }
   const canvas = document.createElement("canvas");
-  const dpr = Math.min(2, window.devicePixelRatio || 1);
+  const dpr =
+    typeof window !== "undefined"
+      ? Math.min(2, window.devicePixelRatio || 1)
+      : 1;
   canvas.width = 256 * dpr;
   canvas.height = 128 * dpr;
   const g = canvas.getContext("2d");


### PR DESCRIPTION
## Summary
- Avoid SSR crashes by checking for `document` and `window` in `makeLabelTexture`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: Override for three@0.172.0 conflicts with direct dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a000e883808321b3c696b6a07290b7