### PR TITLE
Handle main script load errors with user-friendly fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,16 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx" id="main-module"></script>
+    <script>
+      const mainModule = document.getElementById('main-module');
+      mainModule?.addEventListener('error', () => {
+        const root = document.getElementById('root');
+        if (root) {
+          root.innerHTML =
+            '<p style="color:red">Failed to load the application. Please try again later.</p>';
+        }
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- show a friendly message if `/src/main.tsx` fails to load by listening for `error` events on the module script

## Testing
- `node --input-type=module <<'NODE' ... NODE`
- `npm install` *(fails: Override for three@0.172.0 conflicts with direct dependency)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0025259608321bd7c6b50f2037ab3