### PR TITLE
chore: preserve static assets on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/(.*)", "has": [{ "type": "file" }], "destination": "/$1" },
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- ensure static asset paths bypass SPA rewrite on Vercel

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a0025abb888321b87d52c40e46ae8d