### PR TITLE
Switch to HashRouter for SPA routing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@
 import "./bootstrap";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
 
 const root = document.getElementById("root");
@@ -14,11 +14,11 @@ if (!root) {
 } else {
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
-      <BrowserRouter>
+      <HashRouter>
         <Routes>
           <Route path="/*" element={<App />} />
         </Routes>
-      </BrowserRouter>
+      </HashRouter>
     </React.StrictMode>,
   );
 }


### PR DESCRIPTION
## Summary
- replace BrowserRouter with HashRouter in `main.tsx`

## Testing
- `npm install` *(fails: Override for three@0.172.0 conflicts with direct dependency)*
- `npm test` *(fails: vitest not found)*
- `npx vercel deploy --prod --yes` *(fails: Override for three@0.172.0 conflicts with direct dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a002d46e888321936a22b823e25c8d