### PR TITLE
fix: set Vite base to root for Vercel

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: './',          // ← ADD THIS (critical for Vercel)
+  base: '/',          // ← ADD THIS (critical for Vercel)
   build: {
     outDir: 'dist',    // ← ADD THIS (tells Vercel where built files are)
     rollupOptions: {


### PR DESCRIPTION
## Summary
- configure Vite to serve from root (`base: '/'`)

## Testing
- `npm test` *(fails: vitest not found; `npm install` error EOVERRIDE)*
- `npm run build` *(fails: cannot find module 'react', missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a002cf303c83218046cab0f9d223c6