### PR TITLE
Remove redundant feed hydration

### DIFF
--- a/src/components/feed/Feed.test.tsx
+++ b/src/components/feed/Feed.test.tsx
@@ -1,0 +1,40 @@
+// src/components/feed/Feed.test.tsx
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import Feed from "./Feed";
+import { useFeedStore } from "../../lib/feedStore";
+import type { Post } from "../../types";
+
+const samplePosts: Post[] = [
+  { id: 1, author: "@user", images: ["/a.jpg"] } as any,
+  { id: 2, author: "@user2", images: ["/b.jpg"] } as any,
+];
+
+describe("Feed", () => {
+  beforeEach(() => {
+    useFeedStore.getState().setPosts(samplePosts);
+  });
+
+  it("loads posts from store without warnings", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: any) => {
+      return setTimeout(cb, 0) as unknown as number;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id: any) => {
+      clearTimeout(id);
+    });
+
+    const { container, unmount } = render(<Feed />);
+    expect(container.querySelectorAll(".pc").length).toBe(samplePosts.length);
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+
+    unmount();
+    warn.mockRestore();
+    error.mockRestore();
+    (window.requestAnimationFrame as any).mockRestore?.();
+    (window.cancelAnimationFrame as any).mockRestore?.();
+  });
+});

--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import PostCard from "./PostCard";
 import bus from "../../lib/bus";
-import type { Post } from "../../types";
 import { useFeedStore } from "../../lib/feedStore";
 import "./Feed.css";
 
@@ -16,19 +15,10 @@ interface FeedProps {
 
 export default function Feed({ children, style }: FeedProps) {
   const posts = useFeedStore((s) => s.posts);
-  const setPosts = useFeedStore((s) => s.setPosts);
   const [limit, setLimit] = useState(PAGE);
   const limitRef = useRef(limit);
   const visible = useMemo(() => posts.slice(0, limit), [posts, limit]);
   const ref = useRef<HTMLDivElement | null>(null);
-
-  // hydrate posts from global injection if available
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const injected = (window as any).__SN_POSTS__ as Post[] | undefined;
-      if (Array.isArray(injected) && injected.length) setPosts(injected);
-    }
-  }, [setPosts]);
 
   useEffect(() => {
     limitRef.current = limit;


### PR DESCRIPTION
## Summary
- remove `window.__SN_POSTS__` hydration from Feed
- add unit test covering Feed posts rendering without warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a002e24308832184a26aacdeeb24ec