### PR TITLE
fix: update Vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: './',          // ← ADD THIS (critical for Vercel)
+  base: '/',          // ← ADD THIS (critical for Vercel)
   build: {
     outDir: 'dist',    // ← ADD THIS (tells Vercel where built files are)
     rollupOptions: {


### PR DESCRIPTION
## Summary
- ensure assets resolve from root by setting Vite `base` to `/`

## Testing
- `npm install` *(fails: Override for three@0.172.0 conflicts with direct dependency)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: Cannot find module 'react', '@testing-library/react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a002dc9f4c8321a70f7e61d688db57