### PR TITLE
Clarify Vercel-related Vite config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ You can deploy your new Vite project with a single command from your terminal us
 $ vercel
 ```
 
+## Vite configuration for Vercel
+
+The `vite.config.ts` file sets `base: './'` so built assets use relative paths and `build.outDir: 'dist'` because Vercel serves compiled files from that directory.
+
 ## Viewing Console Errors on Vercel
 
 When debugging a production deployment, you can inspect runtime errors in two ways:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: './',          // ← ADD THIS (critical for Vercel)
+  base: './', // ensures relative asset paths for Vercel
   build: {
-    outDir: 'dist',    // ← ADD THIS (tells Vercel where built files are)
+    outDir: 'dist', // Vercel serves files from this directory
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Summary
- clarify Vercel-related options in `vite.config.ts`
- document rationale for `base` and `outDir` settings in README

## Testing
- `npm install` *(fails: Override for three@0.172.0 conflicts with direct dependency)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0046f388c8321af6cd63650ce1f8c