### PR TITLE
Limit rewrite to HTML requests

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "header", "key": "Accept", "value": "text/html" }],
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- only rewrite requests with Accept: text/html to index.html

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a0046327408321858e538aa34772c6