### PR TITLE
fix: defer fallback to DOM ready

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -8,7 +8,13 @@ function showFallback() {
   el.style.cssText =
     'position:fixed;inset:16px;z-index:99999;padding:12px;border-radius:8px;' +
     'background:rgba(0,0,0,0.85);color:#fff;font:14px/1.4 sans-serif;';
-  document.body.appendChild(el);
+  const append = () => {
+    if (document.body) {
+      document.body.appendChild(el);
+    }
+  };
+  if (document.body) append();
+  else document.addEventListener('DOMContentLoaded', append);
 }
 
 window.onerror = function (_message, _source, _lineno, _colno, error) {


### PR DESCRIPTION
## Summary
- Protect fallback DOM insertion by waiting for DOMContentLoaded if `document.body` is unavailable

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0046dee10832188568df75f8203c5