### PR TITLE
Align router basename with Vite base

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,7 @@ if (!root) {
 } else {
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/*" element={<App />} />
         </Routes>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  base: './',          // ← ADD THIS (critical for Vercel)
+  // Base path for serving the app; should align with BrowserRouter basename
+  base: '/',
   build: {
     outDir: 'dist',    // ← ADD THIS (tells Vercel where built files are)
     rollupOptions: {


### PR DESCRIPTION
## Summary
- Pass Vite's deployment base to the router
- Configure Vite base path to align with router

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: TypeScript errors in ThirteenthFloorWorld.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a002d088e88321a537e650eacf089b