### PR TITLE
Switch to BrowserRouter and update rewrites

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@
 import "./bootstrap";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
 
 const root = document.getElementById("root");
@@ -14,11 +14,11 @@ if (!root) {
 } else {
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
-      <HashRouter>
+      <BrowserRouter>
         <Routes>
-          <Route path="/*" element={<App />} />
+          <Route path="*" element={<App />} />
         </Routes>
-      </HashRouter>
+      </BrowserRouter>
     </React.StrictMode>,
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,8 +4,7 @@
   "framework": "vite",
   "rewrites": [
     {
-      "source": "/(.*)",
-      "has": [{ "type": "header", "key": "Accept", "value": "text/html" }],
+      "source": "/((?!.*\\.).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary
- Replace `HashRouter` with `BrowserRouter` and simplify route catch-all
- Ensure SPA routes on Vercel return `index.html` when no file extension is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a008097b7883219aed9eab216127df