### PR TITLE
Ensure Canvas elements fill available space

### DIFF
--- a/src/components/FloatingPortalAssistant.tsx
+++ b/src/components/FloatingPortalAssistant.tsx
@@ -21,15 +21,17 @@ function Orb() {
 export default function FloatingPortalAssistant() {
   return (
     <div className="floating-assistant">
-      <Canvas camera={{ position: [0, 0, 3.2], fov: 50 }} dpr={[1, 1.5]} gl={{ antialias: false }}>
-        <color attach="background" args={['#0a0b10']} />
-        <ambientLight intensity={0.9} />
-        <directionalLight position={[2, 3, 2]} intensity={0.9} />
-        <Float speed={1} rotationIntensity={0.35} floatIntensity={0.9}>
-          <Orb />
-        </Float>
-        <ContactShadows position={[0, -1, 0]} opacity={0.25} scale={10} blur={1.6} far={2} />
-      </Canvas>
+      <div className="r3f-root">
+        <Canvas camera={{ position: [0, 0, 3.2], fov: 50 }} dpr={[1, 1.5]} gl={{ antialias: false }}>
+          <color attach="background" args={['#0a0b10']} />
+          <ambientLight intensity={0.9} />
+          <directionalLight position={[2, 3, 2]} intensity={0.9} />
+          <Float speed={1} rotationIntensity={0.35} floatIntensity={0.9}>
+            <Orb />
+          </Float>
+          <ContactShadows position={[0, -1, 0]} opacity={0.25} scale={10} blur={1.6} far={2} />
+        </Canvas>
+      </div>
     </div>
   );
 }

--- a/src/components/PortalHero.tsx
+++ b/src/components/PortalHero.tsx
@@ -21,15 +21,17 @@ function Knot() {
 export default function PortalHero() {
   return (
     <div className="card" style={{ overflow: 'hidden', borderRadius: 12, border: '1px solid var(--line)', height: 260, background: '#0a0b10' }}>
-      <Canvas camera={{ position: [0, 0, 3.2], fov: 50 }} dpr={[1, 1.5]} gl={{ antialias: false }}>
-        <color attach="background" args={['#0a0b10']} />
-        <ambientLight intensity={0.85} />
-        <directionalLight position={[2, 3, 2]} intensity={0.85} />
-        <Float speed={1} rotationIntensity={0.35} floatIntensity={0.9}>
-          <Knot />
-        </Float>
-        <ContactShadows position={[0, -1, 0]} opacity={0.22} scale={10} blur={1.6} far={2} />
-      </Canvas>
+      <div className="r3f-root">
+        <Canvas camera={{ position: [0, 0, 3.2], fov: 50 }} dpr={[1, 1.5]} gl={{ antialias: false }}>
+          <color attach="background" args={['#0a0b10']} />
+          <ambientLight intensity={0.85} />
+          <directionalLight position={[2, 3, 2]} intensity={0.85} />
+          <Float speed={1} rotationIntensity={0.35} floatIntensity={0.9}>
+            <Knot />
+          </Float>
+          <ContactShadows position={[0, -1, 0]} opacity={0.22} scale={10} blur={1.6} far={2} />
+        </Canvas>
+      </div>
     </div>
   );
 }

--- a/src/components/ThreeCard.tsx
+++ b/src/components/ThreeCard.tsx
@@ -14,13 +14,15 @@ export default function ThreeCard({ variant = 'knot' as 'knot' | 'cube' | 'ico' 
         background: '#0a0b10',
       }}
     >
-      <Canvas camera={{ position: [0, 0, 3.2], fov: 50 }} dpr={[1, 1.5]} gl={{ antialias: false }}>
-        <color attach="background" args={['#0a0b10']} />
-        <ambientLight intensity={0.8} />
-        <directionalLight position={[2, 3, 2]} intensity={0.8} />
-        <Spinner variant={variant} />
-        <ContactShadows position={[0, -1, 0]} opacity={0.25} scale={10} blur={1.6} far={2} />
-      </Canvas>
+      <div className="r3f-root">
+        <Canvas camera={{ position: [0, 0, 3.2], fov: 50 }} dpr={[1, 1.5]} gl={{ antialias: false }}>
+          <color attach="background" args={['#0a0b10']} />
+          <ambientLight intensity={0.8} />
+          <directionalLight position={[2, 3, 2]} intensity={0.8} />
+          <Spinner variant={variant} />
+          <ContactShadows position={[0, -1, 0]} opacity={0.25} scale={10} blur={1.6} far={2} />
+        </Canvas>
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -52,7 +52,9 @@
 }
 
 *{ box-sizing:border-box; }
-html, body, #root { height:100%; }
+html, body, #root { height: 100%; margin: 0; }
+.r3f-root { position: relative; width: 100%; height: 100vh; }
+canvas { display: block; width: 100% !important; height: 100% !important; }
 body{
   margin:0;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji;

--- a/src/three/BackgroundVoid.tsx
+++ b/src/three/BackgroundVoid.tsx
@@ -45,33 +45,35 @@ export default function BackgroundVoid() {
 
   return (
     <div style={{ position: "fixed", inset: 0, zIndex: 0, pointerEvents: "none" }}>
-      <Canvas dpr={[1, 2]} camera={{ position: [0, 0.2, 7], fov: 50 }}>
-        <color attach="background" args={[bg]} />
-        <fog attach="fog" args={[fogC, fogNear, fogFar]} />
-        <ambientLight intensity={1.0} />
-        <directionalLight position={[5, 8, 3]} intensity={0.65} />
-        <FloorGrid color={gridC} opacity={w.gridOpacity} />
-        <Instances limit={64}>
-          <sphereGeometry args={[0.26, 32, 32]} />
-          <meshStandardMaterial
-            color={w.orbColor}
-            emissive={w.theme === "dark" ? "#6b72ff" : "#b6bcff"}
-            emissiveIntensity={0.16}
-            roughness={0.25}
-            metalness={0.55}
-          />
-          {positions.map((p, i) => (
-            <Float
-              key={p.join(",")}
-              floatIntensity={0.6}
-              rotationIntensity={0.25}
-              speed={0.9 + (i % 4) * 0.15}
-            >
-              <Instance position={p} />
-            </Float>
-          ))}
-        </Instances>
-      </Canvas>
+      <div className="r3f-root">
+        <Canvas dpr={[1, 2]} camera={{ position: [0, 0.2, 7], fov: 50 }}>
+          <color attach="background" args={[bg]} />
+          <fog attach="fog" args={[fogC, fogNear, fogFar]} />
+          <ambientLight intensity={1.0} />
+          <directionalLight position={[5, 8, 3]} intensity={0.65} />
+          <FloorGrid color={gridC} opacity={w.gridOpacity} />
+          <Instances limit={64}>
+            <sphereGeometry args={[0.26, 32, 32]} />
+            <meshStandardMaterial
+              color={w.orbColor}
+              emissive={w.theme === "dark" ? "#6b72ff" : "#b6bcff"}
+              emissiveIntensity={0.16}
+              roughness={0.25}
+              metalness={0.55}
+            />
+            {positions.map((p, i) => (
+              <Float
+                key={p.join(",")}
+                floatIntensity={0.6}
+                rotationIntensity={0.25}
+                speed={0.9 + (i % 4) * 0.15}
+              >
+                <Instance position={p} />
+              </Float>
+            ))}
+          </Instances>
+        </Canvas>
+      </div>
     </div>
   );
 }

--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -218,11 +218,13 @@ export default function ThirteenthFloorWorld({
   people?: Person[];
 }) {
   return (
-    <Canvas
-      camera={{ fov: 55, near: 0.1, far: 2000, position: [-90, 58, 130] }}
-      gl={{ antialias: true, powerPreference: "high-performance" }}
-    >
-      <Scene people={people} />
-    </Canvas>
+    <div className="r3f-root">
+      <Canvas
+        camera={{ fov: 55, near: 0.1, far: 2000, position: [-90, 58, 130] }}
+        gl={{ antialias: true, powerPreference: "high-performance" }}
+      >
+        <Scene people={people} />
+      </Canvas>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add global CSS rules for full-height body and Canvas sizing
- Wrap all Canvas components in `r3f-root` divs for proper sizing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0088210d48321a54706ca03464432