### PR TITLE
feat: make emoji bar scrollable and accessible

### DIFF
--- a/src/components/PostCard.test.tsx
+++ b/src/components/PostCard.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import PostCard from "./PostCard";
+
+vi.mock("../lib/bus", () => ({
+  default: { on: () => () => {}, emit: () => {} }
+}));
+
+vi.mock("../lib/ensureModelViewer", () => ({
+  ensureModelViewer: () => Promise.resolve()
+}));
+
+vi.mock("./AmbientWorld", () => ({
+  default: () => <div />
+}));
+
+describe("PostCard emoji accessibility", () => {
+  it("emoji buttons are focusable", () => {
+    const post = { id: 1 } as any;
+    const { container } = render(<PostCard post={post} />);
+    const bar = container.querySelector(".pc-emoji-bar")!;
+    const buttons = Array.from(bar.querySelectorAll("button"));
+    expect(buttons.length).toBeGreaterThan(0);
+    const first = buttons[0] as HTMLButtonElement;
+    first.focus();
+    expect(document.activeElement).toBe(first);
+  });
+});
+

--- a/src/components/postcard.css
+++ b/src/components/postcard.css
@@ -103,7 +103,15 @@
 .pc-drawer{ max-height:0; overflow:hidden; transition:max-height .25s ease, opacity .18s ease, transform .18s ease; opacity:0; transform: translateY(-4px); background: rgba(14,16,24,.65); border-top:1px solid var(--pc-stroke); color:var(--pc-text); max-width:100%; box-sizing:border-box; }
 .pc.dopen .pc-drawer{ max-height: min(80vh, var(--pc-drawer-max)); overflow-y:auto; opacity:1; transform:none; }
 .pc-drawer-inner{ padding:12px 14px; max-width:100%; box-sizing:border-box; }
-.pc-emoji-bar{ display:flex; flex-wrap:wrap; gap:6px; }
+.pc-emoji-bar{
+  display:flex;
+  flex-wrap:nowrap;
+  overflow-x:auto;
+  -webkit-overflow-scrolling:touch;
+  gap:6px;
+  scrollbar-width:none;
+}
+.pc-emoji-bar::-webkit-scrollbar{ display:none; }
 .pc-emoji{ height:var(--pc-emoji-size); min-width:var(--pc-emoji-size); padding:0 6px; border-radius:999px; display:grid; place-items:center; font-size:18px; cursor:pointer; background: rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.12); max-width:100%; box-sizing:border-box; }
 .pc-section{ margin-top:12px; }
 .pc-reactions{ display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }


### PR DESCRIPTION
## Summary
- allow emoji bar to scroll horizontally with touch momentum and hidden scrollbar
- add test ensuring emoji buttons remain focusable via keyboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a011b4916c832188d68c5f351c5128