### PR TITLE
feat: toggle sidebar from BrandBadge click

### DIFF
--- a/src/components/BrandBadge.tsx
+++ b/src/components/BrandBadge.tsx
@@ -9,9 +9,12 @@ export default function BrandBadge({ onEnterUniverse }: { onEnterUniverse: () =>
       <div className="brand-wrap">
         <button
           className="brand-dot"
-          aria-label="Toggle brand menu"
-          onClick={() => setOpen(o => !o)}
-          onDoubleClick={() => bus.emit("sidebar:toggle", undefined)} /* bus.emit expects (event, payload) */
+          aria-label="Toggle sidebar"
+          onClick={() => bus.emit("sidebar:toggle")}
+          onContextMenu={e => {
+            e.preventDefault();
+            setOpen(o => !o);
+          }}
         >
           <img
             src="/supernova.png"


### PR DESCRIPTION
## Summary
- open sidebar when clicking BrandBadge
- access BrandBadge menu via right-click context menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0122b5bb08321adebd9e183066977