### PR TITLE
Lock viewport and remove page scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     >
     <meta name="theme-color" content="#0b0d12">
     <title>superNova portal</title>

--- a/src/components/feed/Feed.css
+++ b/src/components/feed/Feed.css
@@ -1,7 +1,7 @@
 /* Feed layout scoped to component */
 
 .content-viewport {
-  height: 100dvh;
+  height: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain; /* avoid page rubber-band */

--- a/src/index.css
+++ b/src/index.css
@@ -52,7 +52,12 @@
 }
 
 *{ box-sizing:border-box; }
-html, body, #root { height: 100%; margin: 0; }
+html, body, #root, main { height: 100%; margin: 0; }
+html, body {
+  overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
+}
 .r3f-root { position: relative; width: 100%; height: 100vh; }
 canvas { display: block; width: 100% !important; height: 100% !important; }
 body{

--- a/src/portal.css
+++ b/src/portal.css
@@ -6,7 +6,12 @@
   --glass: rgba(255,255,255,.6);
 }
 
-html, body, #root { height: 100%; }
+html, body, #root, main { height: 100%; }
+html, body {
+  overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
+}
 body { background: var(--bg); color: var(--ink); }
 
 .layout{

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,9 +2,16 @@
    Global Reset + Theme
    ========================= */
 *, *::before, *::after { box-sizing: border-box; }
-html, body, #root { height: 100%; }
-html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
-body { overflow-x: hidden; }
+html, body, #root, main { height: 100%; }
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  overflow: hidden;
+  overscroll-behavior: none;
+  touch-action: none;
+}
 img, svg, video, canvas { display: block; max-width: 100%; }
 button, input, textarea, select { font: inherit; color: inherit; }
 :focus-visible { outline: 2px solid #0A84FF; outline-offset: 2px; }


### PR DESCRIPTION
## Summary
- prevent pinch-zoom and disable user scaling in the viewport
- stop body scrolling and overscroll via global CSS
- let feed and other root containers fill the screen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a011aed7588321a70507c089b866ca