### PR TITLE
feat: include post context in assistant queries

### DIFF
--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -1,20 +1,34 @@
 // src/lib/assistant.ts
 import type { AssistantMessage, RemixSpec } from "../types";
 
-export async function askLLM(input: string, ctx?: Record<string, unknown>): Promise<AssistantMessage> {
+export async function askLLM(
+  input: string,
+  ctx?: Record<string, unknown>,
+  apiKey?: string,
+): Promise<AssistantMessage> {
   try {
     const res = await fetch("/api/assistant-reply", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ prompt: input, ctx }),
+      body: JSON.stringify({ prompt: input, ctx, apiKey }),
     });
     if (res.ok) {
       const data = await res.json();
-      return { id: crypto.randomUUID(), role: "assistant", text: data.text || "ok", ts: Date.now() };
+      return {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        text: data.text || "ok",
+        ts: Date.now(),
+      };
     }
   } catch {}
   // offline stub so builds never fail
-  return { id: crypto.randomUUID(), role: "assistant", text: `💡 stub: “${input}”`, ts: Date.now() };
+  return {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    text: `💡 stub: “${input}”`,
+    ts: Date.now(),
+  };
 }
 
 export async function imageToVideo(spec: RemixSpec): Promise<{ ok: boolean; url?: string; error?: string; }> {


### PR DESCRIPTION
## Summary
- use real askLLM helper with stored OpenAI key and hovered post context
- send post id/text to API and include OpenAI key in request
- API endpoint reads ctx to forward post details to OpenAI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a015ab1c248321bf1837cf5a3db290