### PR TITLE
Add model selector and propagate to OpenAI requests

### DIFF
--- a/api/assistant-reply.ts
+++ b/api/assistant-reply.ts
@@ -14,6 +14,7 @@ export default async function handler(
     apiKey?: string;
     prompt?: string;
     q?: string;
+    model?: string;
   };
   const apiKey = process.env.OPENAI_API_KEY || body.apiKey || "";
   if (!apiKey)
@@ -31,12 +32,16 @@ export default async function handler(
   const prompt = (raw || "").trim();
   if (!prompt) return res.status(400).json({ ok: false, error: "Missing prompt" });
 
+  const model = typeof body.model === "string" && body.model.trim()
+    ? body.model.trim()
+    : "gpt-4o-mini";
+
   try {
     const r = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model,
         temperature: 0.3,
         messages: [
           { role: "system", content: "You are the SuperNOVA assistant orb. Reply in one or two concise sentences. No markdown." },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -73,6 +73,10 @@ export default function Sidebar() {
   const [perplexityKey, setPerplexityKey] = useLocal("sn.keys.perplexity", "");
   const [stabilityKey, setStabilityKey] = useLocal("sn.keys.stability", "");
   const [elevenlabsKey, setElevenlabsKey] = useLocal("sn.keys.elevenlabs", "");
+  const [openaiModel, setOpenaiModel] = useLocal(
+    "sn.model.openai",
+    "gpt-4o-mini",
+  );
   const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
   const toggleShow = (k: string) =>
     setShowKeys((s) => ({ ...s, [k]: !s[k] }));
@@ -313,6 +317,21 @@ export default function Sidebar() {
             <button className="key-clear" onClick={clearAll} type="button">
               Clear all keys
             </button>
+          </section>
+
+          <section className="card">
+            <header>AI Model</header>
+            <div className="key-field">
+              <label className="label" htmlFor="model-openai">
+                OpenAI model
+              </label>
+              <input
+                id="model-openai"
+                className="input"
+                value={openaiModel}
+                onChange={(e) => setOpenaiModel(e.target.value)}
+              />
+            </div>
           </section>
 
           {/* Integrations, Privacy, Danger Zone sections ... */}

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -3,10 +3,16 @@ import type { AssistantMessage, RemixSpec } from "../types";
 
 export async function askLLM(input: string, ctx?: Record<string, unknown>): Promise<AssistantMessage> {
   try {
+    let model: string | undefined;
+    try {
+      const raw = localStorage.getItem("sn.model.openai");
+      if (raw) model = JSON.parse(raw);
+    } catch {}
+
     const res = await fetch("/api/assistant-reply", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ prompt: input, ctx }),
+      body: JSON.stringify({ prompt: input, ctx, model }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- allow choosing and persisting an OpenAI model in the sidebar
- send selected model in askLLM requests
- backend uses provided model with fallback to `gpt-4o-mini`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0159a731c8321b81f8bf2f2ab6d3e