### PR TITLE
feat: send post context to assistant

### DIFF
--- a/api/assistant-reply.ts
+++ b/api/assistant-reply.ts
@@ -14,6 +14,7 @@ export default async function handler(
     apiKey?: string;
     prompt?: string;
     q?: string;
+    ctx?: { postId?: string | number; title?: string };
   };
   const apiKey = process.env.OPENAI_API_KEY || body.apiKey || "";
   if (!apiKey)
@@ -31,18 +32,28 @@ export default async function handler(
   const prompt = (raw || "").trim();
   if (!prompt) return res.status(400).json({ ok: false, error: "Missing prompt" });
 
+  const ctx = body.ctx;
+
   try {
+    const messages: Array<{ role: string; content: string }> = [
+      {
+        role: "system",
+        content:
+          "You are the SuperNOVA assistant orb. Reply in one or two concise sentences. No markdown.",
+      },
+    ];
+    if (ctx && (ctx.postId || ctx.title)) {
+      const parts: string[] = [];
+      if (ctx.postId) parts.push(`ID ${ctx.postId}`);
+      if (ctx.title) parts.push(`title \"${ctx.title}\"`);
+      messages.push({ role: "system", content: `User is hovering over post ${parts.join(" ")}.` });
+    }
+    messages.push({ role: "user", content: prompt.slice(0, 2000) });
+
     const r = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: "gpt-4o-mini",
-        temperature: 0.3,
-        messages: [
-          { role: "system", content: "You are the SuperNOVA assistant orb. Reply in one or two concise sentences. No markdown." },
-          { role: "user", content: prompt.slice(0, 2000) },
-        ],
-      }),
+      body: JSON.stringify({ model: "gpt-4o-mini", temperature: 0.3, messages }),
     });
     const j = await r.json();
     if (!r.ok) return res.status(r.status).json({ ok: false, error: j?.error?.message || "Failed" });

--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import bus from "../lib/bus";
 import { logError } from "../lib/logger";
+import { askLLM } from "../lib/assistant";
 import type { AssistantMessage, Post } from "../types";
 import RadialMenu from "./RadialMenu";
 import { HOLD_MS } from "./orbConstants";
@@ -74,10 +75,6 @@ const EMOJI_LIST: string[] = [
   "💙","💜","🖤","🤍","❤️‍🔥","❤️‍🩹","💯","💬","🗯️","🎉","🎊","🎁","🏆","🎮","🚀","✈️","🚗","🏠","🫨","🗿",
   "📱","💡","🎵","📢","📚","📈","✅","❌","❗","❓","‼️","⚠️","🌀","🎬","🍕","🍔","🍎","🍺","⚙️","🧩"
 ];
-
-async function askLLMStub(text: string) {
-  return `🤖 I’m a stub, but I heard: “${text}”`;
-}
 
 function getClosestPostId(el: Element | null): string | null {
   return el?.closest?.("[data-post-id]")?.getAttribute?.("data-post-id") ?? null;
@@ -246,8 +243,8 @@ export default function AssistantOrb() {
       return;
     }
 
-    const resp = await askLLMStub(T);
-    push({ id: uuid(), role: "assistant", text: resp, ts: Date.now() });
+    const resp = await askLLM(T, post);
+    push(resp);
   }
 
   function handleEmojiClick(emoji: string) {

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -1,20 +1,37 @@
 // src/lib/assistant.ts
-import type { AssistantMessage, RemixSpec } from "../types";
+import type { AssistantMessage, RemixSpec, ID } from "../types";
 
-export async function askLLM(input: string, ctx?: Record<string, unknown>): Promise<AssistantMessage> {
+export async function askLLM(
+  input: string,
+  ctxPost?: { id: ID; title?: string } | null,
+): Promise<AssistantMessage> {
   try {
+    const payload: Record<string, unknown> = { prompt: input };
+    if (ctxPost) payload.ctx = { postId: ctxPost.id, title: ctxPost.title };
     const res = await fetch("/api/assistant-reply", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ prompt: input, ctx }),
+      body: JSON.stringify(payload),
     });
     if (res.ok) {
       const data = await res.json();
-      return { id: crypto.randomUUID(), role: "assistant", text: data.text || "ok", ts: Date.now() };
+      return {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        text: data.text || "ok",
+        ts: Date.now(),
+        postId: ctxPost?.id ?? null,
+      };
     }
   } catch {}
   // offline stub so builds never fail
-  return { id: crypto.randomUUID(), role: "assistant", text: `💡 stub: “${input}”`, ts: Date.now() };
+  return {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    text: `💡 stub: “${input}”`,
+    ts: Date.now(),
+    postId: ctxPost?.id ?? null,
+  };
 }
 
 export async function imageToVideo(spec: RemixSpec): Promise<{ ok: boolean; url?: string; error?: string; }> {


### PR DESCRIPTION
## Summary
- attach post context when asking the LLM
- include hovered post description in `/api/assistant-reply`
- forward hovered post data from `AssistantOrb` to `askLLM`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01595c4d48321a4aa6d9ada270ba7