### PR TITLE
Add emoji reaction handler for AssistantOrb

### DIFF
--- a/src/components/AssistantOrb.tsx
+++ b/src/components/AssistantOrb.tsx
@@ -272,6 +272,27 @@ export default function AssistantOrb() {
     push(resp);
   }
 
+  function handleEmojiClick(emoji: string) {
+    const post = ctxPost;
+    if (post) {
+      bus.emit?.("post:react", { id: post.id, emoji });
+      push({
+        id: uuid(),
+        role: "assistant",
+        text: `✨ Reacted ${emoji} on ${post.id}`,
+        ts: Date.now(),
+        postId: post.id,
+      });
+    } else {
+      push({
+        id: uuid(),
+        role: "assistant",
+        text: "⚠️ Drag the orb over a post first.",
+        ts: Date.now(),
+      });
+    }
+  }
+
   // hover highlight
   function setHover(id: string | null) {
     if (hoverIdRef.current) {


### PR DESCRIPTION
## Summary
- implement `handleEmojiClick` to emit `post:react` events and log reactions in chat

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01b2902c88321bd7972c9984bf822