### PR TITLE
feat: add interactive 3D world placeholder

### DIFF
--- a/src/components/PostCard.test.tsx
+++ b/src/components/PostCard.test.tsx
@@ -11,7 +11,7 @@ vi.mock("../lib/ensureModelViewer", () => ({
   ensureModelViewer: () => Promise.resolve()
 }));
 
-vi.mock("./AmbientWorld", () => ({
+vi.mock("../three/ThirteenthFloorWorld", () => ({
   default: () => <div />
 }));
 

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,7 +4,7 @@ import "./postcard.css";
 import type { Post } from "../types";
 import bus from "../lib/bus";
 import { ensureModelViewer } from "../lib/ensureModelViewer";
-import AmbientWorld from "./AmbientWorld";
+import ThirteenthFloorWorld from "../three/ThirteenthFloorWorld";
 
 const isBlob = (u?: string | null) => !!u && u.startsWith("blob:");
 
@@ -151,7 +151,7 @@ export default function PostCard({ post }: { post: Post }) {
               onLoad={onMediaReady}
             />
           ) : (
-            <AmbientWorld className="pc-media" />
+            <ThirteenthFloorWorld className="pc-media" style={{ height: "56vw" }} />
           )}
         </div>
 

--- a/src/components/feed/PostCard.test.tsx
+++ b/src/components/feed/PostCard.test.tsx
@@ -4,6 +4,11 @@ import { render, fireEvent } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import PostCard from "./PostCard";
 import type { Post } from "../../types";
+import { vi } from "vitest";
+
+vi.mock("../../three/ThirteenthFloorWorld", () => ({
+  default: () => <div />,
+}));
 
 describe("PostCard image grid", () => {
   const post: Post = {

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -3,7 +3,7 @@ import "./postcard.css";
 import type { Post } from "../../types";
 import bus from "../../lib/bus";
 import { ensureModelViewer } from "../../lib/ensureModelViewer";
-import AmbientWorld from "../AmbientWorld";
+import ThirteenthFloorWorld from "../../three/ThirteenthFloorWorld";
 
 const OR = (a: any, b: any) => (a ?? b);
 
@@ -197,7 +197,7 @@ export default function PostCard({ post }: { post: Post }) {
               style={{ opacity: 0 }}
             />
           ) : (
-            <AmbientWorld />
+            <ThirteenthFloorWorld style={{ height: "56vw" }} />
           )}
         </div>
 

--- a/src/three/ThirteenthFloorWorld.tsx
+++ b/src/three/ThirteenthFloorWorld.tsx
@@ -214,11 +214,18 @@ export default function ThirteenthFloorWorld({
     { id: "uno", name: "uno", color: "#9effb8" },
     { id: "jin", name: "jin", color: "#86ffaa" },
   ],
+  className,
+  style,
 }: {
   people?: Person[];
+  className?: string;
+  style?: React.CSSProperties;
 }) {
   return (
-    <div className="r3f-root">
+    <div
+      className={["r3f-root", className].filter(Boolean).join(" ")}
+      style={style}
+    >
       <Canvas
         camera={{ fov: 55, near: 0.1, far: 2000, position: [-90, 58, 130] }}
         gl={{ antialias: true, powerPreference: "high-performance" }}


### PR DESCRIPTION
## Summary
- show ThirteenthFloorWorld for posts without media
- allow ThirteenthFloorWorld to accept className/style for flexible sizing
- update unit tests for new 3D placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0201d884c8321aa4e4273150a261d