### PR TITLE
feat: add neon ribbon post composer

### DIFF
--- a/src/components/NeonRibbonComposer.tsx
+++ b/src/components/NeonRibbonComposer.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import PostComposer from "./PostComposer";
+import "./neon-ribbon.css";
+
+export default function NeonRibbonComposer() {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLDivElement>(null);
+
+  const openComposer = useCallback(() => setOpen(true), []);
+  const closeComposer = useCallback(() => {
+    setOpen(false);
+    toggleRef.current?.focus();
+  }, []);
+
+  // global shortcuts
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!open && e.key === "/") {
+        const t = e.target as HTMLElement;
+        if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+        e.preventDefault();
+        setOpen(true);
+      } else if (open && e.key === "Escape") {
+        e.preventDefault();
+        closeComposer();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, closeComposer]);
+
+  // autofocus textarea on open
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => {
+      const ta = containerRef.current?.querySelector<HTMLTextAreaElement>("textarea");
+      ta?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  // focus trap when open
+  useEffect(() => {
+    if (!open) return;
+    function trap(e: KeyboardEvent) {
+      if (e.key !== "Tab") return;
+      const nodes = containerRef.current?.querySelectorAll<HTMLElement>(
+        'a,button,input,textarea,select,[tabindex]:not([tabindex="-1"])'
+      );
+      if (!nodes || nodes.length === 0) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+    const node = containerRef.current;
+    node?.addEventListener("keydown", trap);
+    return () => node?.removeEventListener("keydown", trap);
+  }, [open]);
+
+  const handleToggleKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openComposer();
+      }
+    },
+    [openComposer]
+  );
+
+  return (
+    <div ref={containerRef} className={`neon-ribbon${open ? " expanded" : ""}`}>
+      {!open && (
+        <div
+          ref={toggleRef}
+          className="neon-ribbon__toggle"
+          role="button"
+          tabIndex={0}
+          aria-expanded={open}
+          aria-label="Compose new post"
+          onClick={openComposer}
+          onKeyDown={handleToggleKey}
+        >
+          <span aria-hidden="true" className="neon-ribbon__line" />
+        </div>
+      )}
+      {open && <PostComposer />}
+    </div>
+  );
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -7,7 +7,7 @@ import MenuOrb from "./MenuOrb";
 import ChatDock from "./ChatDock";
 import Sidebar from "./Sidebar";
 import PortalOverlay from "./PortalOverlay";
-import PostComposer from "./PostComposer";
+import NeonRibbonComposer from "./NeonRibbonComposer";
 import AvatarPortal from "./AvatarPortal";
 
 export default function Shell() {
@@ -22,11 +22,8 @@ export default function Shell() {
       <PortalOverlay />
 
       <main>
-        <Feed>
-          <div style={{ padding: "12px 0" }}>
-            <PostComposer />
-          </div>
-        </Feed>
+        <NeonRibbonComposer />
+        <Feed />
       </main>
 
       <ChatDock />

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,8 @@ export { default as Feed } from "./Feed";
 // ...or directly:
 // export { default as Feed } from "./feed/Feed";
 
+export { default as NeonRibbonComposer } from "./NeonRibbonComposer";
+
 export { default as ErrorBoundary } from "./ErrorBoundary";
 
 export type { Post } from "../types";

--- a/src/components/neon-ribbon.css
+++ b/src/components/neon-ribbon.css
@@ -1,0 +1,48 @@
+.neon-ribbon {
+  position: sticky;
+  top: var(--topbar-h);
+  z-index: 20;
+  width: 100%;
+  overflow: hidden;
+  max-height: 48px;
+  transition: max-height 0.3s ease;
+}
+
+.neon-ribbon.expanded {
+  max-height: 100vh;
+}
+
+.neon-ribbon__toggle {
+  height: 48px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+}
+
+.neon-ribbon__line {
+  width: 100%;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--blue) 65%, transparent),
+    color-mix(in srgb, var(--blue) 20%, transparent),
+    color-mix(in srgb, var(--blue) 65%, transparent)
+  );
+  background-size: 200% 100%;
+  animation: ribbon-shimmer 2s linear infinite;
+  box-shadow: 0 0 8px color-mix(in srgb, var(--blue) 40%, transparent);
+}
+
+@keyframes ribbon-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neon-ribbon__line { animation: none; }
+}


### PR DESCRIPTION
## Summary
- add NeonRibbonComposer collapsed ribbon with neon shimmer and keyboard support
- render new composer at top of Shell and export from components barrel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01fd50e0883218af4d5f13856c689