### PR TITLE
feat: add scene selector and sidebar polish

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -9,13 +9,25 @@ import Sidebar from "./Sidebar";
 import PortalOverlay from "./PortalOverlay";
 import PostComposer from "./PostComposer";
 import AvatarPortal from "./AvatarPortal";
+import BackgroundVoid from "../three/BackgroundVoid";
+import ThirteenthFloorWorld from "../three/ThirteenthFloorWorld";
+import useLocal from "../hooks/useLocal";
 
 export default function Shell() {
+  const [worldMode] = useLocal<"orbs" | "void" | "floor">("sn.world.mode", "orbs");
+  const world =
+    worldMode === "floor" ? (
+      <ThirteenthFloorWorld />
+    ) : worldMode === "void" ? (
+      <BackgroundVoid />
+    ) : (
+      <World3D />
+    );
   return (
     <>
       {/* 3D world behind everything */}
       <div className="world-layer" aria-hidden>
-        <World3D />
+        {world}
       </div>
       <MenuOrb />
       <Sidebar />

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -59,6 +59,13 @@
   box-shadow: 0 28px 64px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.05);
   padding: 14px;
   box-sizing:border-box;
+  opacity: 0;
+  transform: translateX(-12px) scale(.96);
+  transition: transform var(--sb-duration) var(--sb-ease), opacity var(--sb-duration) var(--sb-ease);
+}
+.sb.open .sb-panel {
+  opacity: 1;
+  transform: none;
 }
 
 @media (max-width: 400px) {
@@ -173,3 +180,29 @@
   }
 }
 
+.world-select {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+.world-option {
+  flex: 1;
+  padding: 6px 0;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,.16);
+  background: rgba(255,255,255,.08);
+  color: inherit;
+  cursor: pointer;
+  transition: background var(--sb-duration) var(--sb-ease), transform var(--sb-duration) var(--sb-ease);
+}
+.world-option:hover {
+  background: rgba(255,255,255,.16);
+}
+.world-option.on {
+  background: var(--accent);
+  color: #000;
+}
+.world-option:active {
+  transform: scale(.94);
+}
+.orb-slider { margin-top: 12px; }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,25 +3,8 @@ import { NavLink } from "react-router-dom";
 import "./Sidebar.css";
 import bus from "../lib/bus";
 import { useTheme } from "../lib/useTheme";
+import useLocal from "../hooks/useLocal";
 
-function useLocal<T>(key: string, init: T) {
-  const [v, setV] = useState<T>(() => {
-    if (typeof window === "undefined") return init;
-    try {
-      const raw = window.localStorage.getItem(key);
-      return raw ? (JSON.parse(raw) as T) : init;
-    } catch {
-      return init;
-    }
-  });
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(key, JSON.stringify(v));
-    } catch {}
-  }, [key, v]);
-  return [v, setV] as const;
-}
 
 export default function Sidebar() {
   const [open, setOpen] = useLocal("sn.sidebar.open", false);
@@ -58,7 +41,7 @@ export default function Sidebar() {
 
   const [theme, setTheme] = useTheme();
   const [accent, setAccent] = useLocal("sn.accent", "#7c83ff");
-  const [worldMode, setWorldMode] = useLocal<"orbs" | "matrix">(
+  const [worldMode, setWorldMode] = useLocal<"orbs" | "void" | "floor">(
     "sn.world.mode",
     "orbs"
   );
@@ -259,19 +242,28 @@ export default function Sidebar() {
               </div>
             </div>
 
-            <div className="grid two">
-              <div>
-                <label className="label">Background</label>
-                <select
-                  className="input"
-                  value={worldMode}
-                  onChange={(e) => setWorldMode(e.target.value as any)}
-                >
-                  <option value="orbs">Orb Mesh</option>
-                  <option value="matrix">Matrix Drift</option>
-                </select>
+            <div>
+              <label className="label">Background</label>
+              <div className="world-select">
+                {[
+                  { id: "orbs", label: "🔮" },
+                  { id: "void", label: "🌌" },
+                  { id: "floor", label: "🏢" },
+                ].map((w) => (
+                  <button
+                    key={w.id}
+                    type="button"
+                    className={`world-option ${worldMode === w.id ? "on" : ""}`}
+                    onClick={() => setWorldMode(w.id as any)}
+                    aria-label={w.id}
+                  >
+                    {w.label}
+                  </button>
+                ))}
               </div>
-              <div>
+            </div>
+            {worldMode === "orbs" && (
+              <div className="orb-slider">
                 <label className="label">Orb density</label>
                 <input
                   className="input"
@@ -283,8 +275,8 @@ export default function Sidebar() {
                   onChange={(e) => setOrbCount(parseInt(e.target.value, 10))}
                 />
               </div>
-            </div>
-            <p className="hint">Changes apply instantly and persist on this device.</p>
+            )}
+              <p className="hint">Changes apply instantly and persist on this device.</p>
           </section>
 
           <section className="card">

--- a/src/hooks/useLocal.ts
+++ b/src/hooks/useLocal.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export function useLocal<T>(key: string, init: T) {
+  const [v, setV] = useState<T>(() => {
+    if (typeof window === "undefined") return init;
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as T) : init;
+    } catch {
+      return init;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(v));
+    } catch {}
+  }, [key, v]);
+
+  return [v, setV] as const;
+}
+
+export default useLocal;


### PR DESCRIPTION
## Summary
- add reusable `useLocal` hook for localStorage state
- enhance sidebar with animated panel and scene selector
- allow switching between Orb Mesh, Background Void, and Thirteenth Floor worlds

## Testing
- `PATH=/bin:/usr/bin:/root/.local/share/mise/installs/node/20.19.4/bin /root/.local/share/mise/installs/node/20.19.4/bin/npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a021553d748321b90e81d9e2f83c96