### PR TITLE
feat: add shimmer to assistant orb

### DIFF
--- a/src/components/orbs.css
+++ b/src/components/orbs.css
@@ -80,7 +80,8 @@
   --orb-d: 56px;
   z-index: 60;
 }
-.orb--menu .orb__core::after {
+.orb--menu .orb__core::after,
+.orb--assistant .orb__core::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -98,7 +99,8 @@
   .orb__ring,
   .orb--assistant.is-mic .orb__core,
   .orb--assistant.is-mic .orb__ring,
-  .orb--menu .orb__core::after {
+  .orb--menu .orb__core::after,
+  .orb--assistant .orb__core::after {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary
- add shimmer animation to pink assistant orb matching menu orb
- respect reduced-motion preference for new animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1333ca178832193fa28b37e187466